### PR TITLE
added check for content-type "application/graphql" in django view

### DIFF
--- a/graphene/contrib/django/views.py
+++ b/graphene/contrib/django/views.py
@@ -60,6 +60,8 @@ class GraphQLView(View):
                 query = received_json_data.get('query')
             except ValueError:
                 return self.response_errors(ValueError("Malformed json body in the post data"))
+        elif content_type == 'application/graphql':
+            query = request.body.decode()
         else:
             query = request.POST.get('query') or request.GET.get('query')
         return self.execute_query(request, query or '')

--- a/tests/contrib_django/test_views.py
+++ b/tests/contrib_django/test_views.py
@@ -104,7 +104,7 @@ def test_client_post_good_query_json(settings, client):
 def test_client_post_good_query_graphql(settings, client):
     settings.ROOT_URLCONF = 'tests.contrib_django.test_urls'
     response = client.post(
-        '/graphql', '{ headline }'), 'application/graphql')
+        '/graphql', '{ headline }', 'application/graphql')
     json_response = format_response(response)
     expected_json = {
         'data': {

--- a/tests/contrib_django/test_views.py
+++ b/tests/contrib_django/test_views.py
@@ -29,7 +29,7 @@ def test_client_post_malformed_json(settings, client):
         {'message': 'Malformed json body in the post data'}]}
 
 
-def test_client_post_empty_query(settings, client):
+def test_client_post_empty_query_json(settings, client):
     settings.ROOT_URLCONF = 'tests.contrib_django.test_urls'
     response = client.post(
         '/graphql', json.dumps({'query': ''}), 'application/json')
@@ -38,10 +38,29 @@ def test_client_post_empty_query(settings, client):
         {'message': 'Must provide query string.'}]}
 
 
-def test_client_post_bad_query(settings, client):
+def test_client_post_empty_query_graphql(settings, client):
+    settings.ROOT_URLCONF = 'tests.contrib_django.test_urls'
+    response = client.post(
+        '/graphql', '', 'application/graphql')
+    json_response = format_response(response)
+    assert json_response == {'errors': [
+        {'message': 'Must provide query string.'}]}
+
+
+def test_client_post_bad_query_json(settings, client):
     settings.ROOT_URLCONF = 'tests.contrib_django.test_urls'
     response = client.post(
         '/graphql', json.dumps({'query': '{ MALFORMED'}), 'application/json')
+    json_response = format_response(response)
+    assert 'errors' in json_response
+    assert len(json_response['errors']) == 1
+    assert 'Syntax Error GraphQL' in json_response['errors'][0]['message']
+
+
+def test_client_post_bad_query_graphql(settings, client):
+    settings.ROOT_URLCONF = 'tests.contrib_django.test_urls'
+    response = client.post(
+        '/graphql', '{ MALFORMED', 'application/graphql')
     json_response = format_response(response)
     assert 'errors' in json_response
     assert len(json_response['errors']) == 1
@@ -69,10 +88,23 @@ def test_client_get_good_query_with_raise(settings, client):
     assert json_response['data']['raises'] is None
 
 
-def test_client_post_good_query(settings, client):
+def test_client_post_good_query_json(settings, client):
     settings.ROOT_URLCONF = 'tests.contrib_django.test_urls'
     response = client.post(
         '/graphql', json.dumps({'query': '{ headline }'}), 'application/json')
+    json_response = format_response(response)
+    expected_json = {
+        'data': {
+            'headline': None
+        }
+    }
+    assert json_response == expected_json
+
+
+def test_client_post_good_query_graphql(settings, client):
+    settings.ROOT_URLCONF = 'tests.contrib_django.test_urls'
+    response = client.post(
+        '/graphql', '{ headline }'), 'application/graphql')
     json_response = format_response(response)
     expected_json = {
         'data': {


### PR DESCRIPTION
The `GraphQLView` in contrib/django now also accepts content-type "application/graphql", for which it simply uses the request body as the query.