### PR TITLE
Add the info parameter (ResolveInfo) to get_node() calls.

### DIFF
--- a/examples/starwars_django/schema.py
+++ b/examples/starwars_django/schema.py
@@ -17,7 +17,7 @@ class Ship(DjangoNode):
         model = ShipModel
 
     @classmethod
-    def get_node(cls, id):
+    def get_node(cls, id, info):
         return Ship(get_ship(id))
 
 
@@ -33,7 +33,7 @@ class Faction(DjangoNode):
         model = FactionModel
 
     @classmethod
-    def get_node(cls, id):
+    def get_node(cls, id, info):
         return Faction(get_faction(id))
 
 

--- a/examples/starwars_relay/schema.py
+++ b/examples/starwars_relay/schema.py
@@ -11,7 +11,7 @@ class Ship(relay.Node):
     name = graphene.String(description='The name of the ship.')
 
     @classmethod
-    def get_node(cls, id):
+    def get_node(cls, id, info):
         return get_ship(id)
 
 
@@ -27,7 +27,7 @@ class Faction(relay.Node):
         return [get_ship(ship_id) for ship_id in self.ships]
 
     @classmethod
-    def get_node(cls, id):
+    def get_node(cls, id, info):
         return get_faction(id)
 
 

--- a/graphene/contrib/django/tests/test_query.py
+++ b/graphene/contrib/django/tests/test_query.py
@@ -66,7 +66,7 @@ def test_should_node():
             model = Reporter
 
         @classmethod
-        def get_node(cls, id):
+        def get_node(cls, id, info):
             return ReporterNode(Reporter(id=2, first_name='Cookie Monster'))
 
         def resolve_articles(self, *args, **kwargs):
@@ -78,7 +78,7 @@ def test_should_node():
             model = Article
 
         @classmethod
-        def get_node(cls, id):
+        def get_node(cls, id, info):
             return ArticleNode(Article(id=1, headline='Article node'))
 
     class Query(graphene.ObjectType):

--- a/graphene/relay/fields.py
+++ b/graphene/relay/fields.py
@@ -92,7 +92,7 @@ class NodeField(Field):
                                         object_type != self.field_object_type):
             return
 
-        return object_type.get_node(_id)
+        return object_type.get_node(_id, info)
 
     def resolver(self, instance, args, info):
         global_id = args.get('id')


### PR DESCRIPTION
This allows request_context (or any other ResolveInfo data) to be used while getting nodes.
For example, some data might need to be hidden based on the user's authorization; you would use info.request_context for this.

Fixes #34.