### PR TITLE
Simple example of using a Python object as a field to query on

### DIFF
--- a/examples/field_example.py
+++ b/examples/field_example.py
@@ -1,0 +1,30 @@
+import graphene
+
+class Person(graphene.Interface):
+    name = graphene.String()
+    age = graphene.ID()
+
+class Patron(Person):
+    id = graphene.ID()
+
+class Query(graphene.ObjectType):
+
+    patron = graphene.Field(Patron)
+
+    def resolve_patron(self, args, info):
+        return Patron(id=1, name='Demo')
+
+schema = graphene.Schema(query=Query)
+query = '''
+    query something{
+      patron {
+        id
+        name
+      }
+}
+'''
+result = schema.execute(query)
+# Print the result
+print result.data['patron']
+
+

--- a/graphene/contrib/django/tests/test_types.py
+++ b/graphene/contrib/django/tests/test_types.py
@@ -89,6 +89,7 @@ def test_interface_objecttype_init_unexpected():
         Human(object())
     assert str(excinfo.value) == "Human received a non-compatible instance (object) when expecting Article"
 
+
 def test_object_type():
     object_type = schema.T(Human)
     Human._meta.fields_map

--- a/graphene/core/types/field.py
+++ b/graphene/core/types/field.py
@@ -79,6 +79,7 @@ class Field(OrderedType):
             resolver = getattr(type_objecttype, 'mutate')
         else:
             my_resolver = resolver
+
             @wraps(my_resolver)
             def wrapped_func(instance, args, info):
                 if not isinstance(instance, self.object_type):


### PR DESCRIPTION
While getting started, I did not find a simple example of what I wanted to do here - query a Python object type and not a scalar field. Hopefully this is a good addition.
