### PR TITLE
Update quickstart example

### DIFF
--- a/quickstart.md
+++ b/quickstart.md
@@ -43,7 +43,7 @@ schema = graphene.Schema()
 
 # This will be our root query
 class Query(graphene.ObjectType):
-    username = graphene.StringField(description='The username')
+    username = graphene.String(description='The username')
 
    	def resolve_username(self, *args):
    		return 'Hello World'


### PR DESCRIPTION
Running the example previously resulted in a `FutureWarning`.

```bash
…/graphene/core/fields.py:14: FutureWarning: Using StringField is not longer supported
  cls.__name__), FutureWarning)
```

```
blinker==1.4
graphene==0.4.1.1
graphql-core==0.4.9
graphql-relay==0.3.3
six==1.10.0
wsgiref==0.1.2
```