### PR TITLE
Add documentation about using custom input object types as arguments

### DIFF
--- a/docs/pages/docs/basic-types.md
+++ b/docs/pages/docs/basic-types.md
@@ -82,3 +82,21 @@ graphene.Field(graphene.String(), to=graphene.String())
 # Is equivalent to:
 graphene.Field(graphene.String(), to=graphene.Argument(graphene.String()))
 ```
+
+
+## Using custom object types as argument
+
+To use a custom object type as an argument, you need to inherit `graphene.InputObjectType`, not `graphene.ObjectType`.
+
+```python
+class CustomArgumentObjectType(graphene.InputObjectType):
+    field1 = graphene.String()
+    field2 = graphene.String()
+
+```
+
+Then, when defining this in an argument, you need to wrap it in an `Argument` object.
+
+```python
+graphene.Field(graphene.String(), to=graphene.Argument(CustomArgumentObjectType))
+```


### PR DESCRIPTION
This document is based on my reading of the tests.

Ideally, without reading the test, I attempted to create a custom type using normal means, and providing it as an argument again as normal means.

After lots of head scratching, I found the solution, but maybe the behaviour could be fixed at the library level so that the following works:
```python
class CustomArgumentObjectType(graphene.ObjectType):
    field1 = graphene.String()
    field2 = graphene.String()
```
And then:

```
graphene.Field(graphene.String(), to=CustomArgumentObjectType())

```