### PR TITLE
Fixed NodeField object_type string name argument.

### DIFF
--- a/graphene/relay/fields.py
+++ b/graphene/relay/fields.py
@@ -1,3 +1,4 @@
+import six
 from graphql_relay.node.node import from_global_id
 
 from ..core.fields import Field
@@ -73,8 +74,11 @@ class NodeField(Field):
             return None
         _type, _id = resolved_global_id.type, resolved_global_id.id
         object_type = schema.get_type(_type)
-        if not is_node(object_type) or (self.field_object_type and
-                                        object_type != self.field_object_type):
+        if isinstance(self.field_object_type, six.string_types):
+            field_object_type = schema.get_type(self.field_object_type)
+        else:
+            field_object_type = self.field_object_type
+        if not is_node(object_type) or (self.field_object_type and object_type != field_object_type):
             return
 
         return object_type.get_node(_id, info)

--- a/graphene/relay/tests/test_query.py
+++ b/graphene/relay/tests/test_query.py
@@ -31,6 +31,7 @@ class SpecialNode(relay.Node):
 
 class Query(graphene.ObjectType):
     my_node = relay.NodeField(MyNode)
+    my_node_lazy = relay.NodeField('MyNode')
     special_node = relay.NodeField(SpecialNode)
     all_my_nodes = relay.ConnectionField(
         MyNode, connection_type=MyConnection, customArg=graphene.String())
@@ -117,3 +118,23 @@ def test_nodeidfield():
     id_field_type = schema.T(id_field)
     assert isinstance(id_field_type.type, GraphQLNonNull)
     assert id_field_type.type.of_type == GraphQLID
+
+
+def test_nodefield_lazy_query():
+    query = '''
+    query RebelsShipsQuery {
+      myNode(id:"TXlOb2RlOjE=") {
+        id
+        name
+      },
+      myNodeLazy(id:"TXlOb2RlOjE=") {
+        id
+        name
+      },
+
+    }
+    '''
+    result = schema.execute(query)
+    assert not result.errors
+    assert result.data['myNode'] == result.data['myNodeLazy'], \
+        "NodeField with object_type direct reference and with object_type string name should not differ."


### PR DESCRIPTION
Hey, I found bug related to ```relay.NodeField('MyNode')``` behavior, which I assume should be exactly the same as using ```relay.NodeField(MyNode)```. Here is simple fix for that.