### PR TITLE
Added source argument in Fields

### DIFF
--- a/graphene/core/classtypes/objecttype.py
+++ b/graphene/core/classtypes/objecttype.py
@@ -46,6 +46,9 @@ class ObjectType(six.with_metaclass(ObjectTypeMeta, FieldsClassType)):
     class Meta:
         abstract = True
 
+    def __getattr__(self, name):
+        return self._root and getattr(self._root, name)
+
     def __init__(self, *args, **kwargs):
         signals.pre_init.send(self.__class__, args=args, kwargs=kwargs)
         self._root = kwargs.pop('_root', None)

--- a/graphene/core/types/tests/test_field.py
+++ b/graphene/core/types/tests/test_field.py
@@ -180,3 +180,41 @@ def test_field_internal_type_deprecated():
     type = schema.T(field)
     assert isinstance(type, GraphQLField)
     assert type.deprecation_reason == deprecation_reason
+
+
+def test_field_resolve_object():
+    class Root(object):
+        att = True
+
+        @staticmethod
+        def att_func():
+            return True
+
+    field = Field(String(), description='My argument')
+    field_func = Field(String(), description='My argument')
+
+    class Query(ObjectType):
+        att = field
+        att_func = field_func
+
+    assert field.resolver(Root, {}, None) is True
+    assert field.resolver(Root, {}, None) is True
+
+
+def test_field_resolve_source_object():
+    class Root(object):
+        att_source = True
+
+        @staticmethod
+        def att_func_source():
+            return True
+
+    field = Field(String(), source='att_source', description='My argument')
+    field_func = Field(String(), source='att_source', description='My argument')
+
+    class Query(ObjectType):
+        att = field
+        att_func = field_func
+
+    assert field.resolver(Root, {}, None) is True
+    assert field.resolver(Root, {}, None) is True

--- a/graphene/utils/__init__.py
+++ b/graphene/utils/__init__.py
@@ -1,11 +1,12 @@
 from .str_converters import to_camel_case, to_snake_case
 from .proxy_snake_dict import ProxySnakeDict
 from .caching import cached_property, memoize
+from .maybe_func import maybe_func
 from .misc import enum_to_graphql_enum
 from .resolve_only_args import resolve_only_args
 from .lazylist import LazyList
 
 
 __all__ = ['to_camel_case', 'to_snake_case', 'ProxySnakeDict',
-           'cached_property', 'memoize', 'enum_to_graphql_enum',
+           'cached_property', 'memoize', 'maybe_func', 'enum_to_graphql_enum',
            'resolve_only_args', 'LazyList']

--- a/graphene/utils/maybe_func.py
+++ b/graphene/utils/maybe_func.py
@@ -1,0 +1,7 @@
+import inspect
+
+
+def maybe_func(f):
+    if inspect.isfunction(f):
+        return f()
+    return f

--- a/graphene/utils/tests/test_maybe_func.py
+++ b/graphene/utils/tests/test_maybe_func.py
@@ -1,0 +1,9 @@
+from ..maybe_func import maybe_func
+
+
+def maybe_func_function():
+    assert maybe_func(lambda: True) is True
+
+
+def maybe_func_value():
+    assert maybe_func(True) is True


### PR DESCRIPTION
As reflected in issue #101, this pull request adds the ability on `Field`s to support mapping to an `instance` attribute different than the field name, allowing the following to be possible:

```python
class ArtworkNode(DjangoNode):
    url = graphene.String(source='get_absolute_url')

    class Meta:
        model = Artwork
        filter_fields = ['id', 'title']
```