### PR TITLE
Resolve lambda fields at runtime

### DIFF
--- a/graphene/core/types/base.py
+++ b/graphene/core/types/base.py
@@ -5,6 +5,8 @@ import six
 
 
 class InstanceType(object):
+    def _get_true_type(self, _type):
+        return _type() if ('function' in str(type(_type))) else _type
 
     def internal_type(self, schema):
         raise NotImplementedError("internal_type for type {} is not implemented".format(self.__class__.__name__))

--- a/graphene/core/types/definitions.py
+++ b/graphene/core/types/definitions.py
@@ -12,13 +12,16 @@ class OfType(MountedType):
         self.of_type = of_type
         super(OfType, self).__init__(*args, **kwargs)
 
+    def get_type(self):
+        return self._get_true_type(self.of_type)
+
     def internal_type(self, schema):
-        return self.T(schema.T(self.of_type))
+        return self.T(schema.T(self.get_type()))
 
     def mount(self, cls):
         self.parent = cls
         if isinstance(self.of_type, MountType):
-            self.of_type.mount(cls)
+            self.get_type().mount(cls)
 
 
 class List(OfType):

--- a/graphene/core/types/field.py
+++ b/graphene/core/types/field.py
@@ -80,9 +80,10 @@ class Field(NamedType, OrderedType):
         return default_getter
 
     def get_type(self, schema):
+        _type = self._get_true_type(self.type)
         if self.required:
-            return NonNull(self.type)
-        return self.type
+            return NonNull(_type)
+        return _type
 
     def decorate_resolver(self, resolver):
         return snake_case_args(resolver)


### PR DESCRIPTION
Resolves #110 

The following is now also valid and allow for circular dependencies to be resolved at runtime.

```py
# category_type.py
class Category(graphene.ObjectType):
Post = graphene.List(lambda: Post)

from .post_type import Post

# post_type.py
class Post(graphene.ObjectType):
category = graphene.Field(lambda: Category)

from .category_type import Category
```