### PR TITLE
Fix Connections and Filters for use a manager as default value

### DIFF
--- a/graphene/contrib/django/debug/sql/tracking.py
+++ b/graphene/contrib/django/debug/sql/tracking.py
@@ -117,7 +117,7 @@ class NormalCursorWrapper(object):
                 'sql': self.db.ops.last_executed_query(
                     self.cursor, sql, self._quote_params(params)),
                 'duration': duration,
-                'raw_sql': sql % params,
+                'raw_sql': sql,
                 'params': _params,
                 'start_time': start_time,
                 'stop_time': stop_time,

--- a/graphene/contrib/django/debug/tests/test_query.py
+++ b/graphene/contrib/django/debug/tests/test_query.py
@@ -117,7 +117,7 @@ def test_should_query_connection():
     class Query(graphene.ObjectType):
         all_reporters = DjangoConnectionField(ReporterType)
 
-        def resolve_all_reporters_connection(self, *args, **kwargs):
+        def resolve_all_reporters(self, *args, **kwargs):
             return Reporter.objects.all()
 
     query = '''
@@ -172,7 +172,7 @@ def test_should_query_connectionfilter():
     class Query(graphene.ObjectType):
         all_reporters = DjangoFilterConnectionField(ReporterType)
 
-        def resolve_all_reporters_connection_filter(self, *args, **kwargs):
+        def resolve_all_reporters(self, *args, **kwargs):
             return Reporter.objects.all()
 
     query = '''

--- a/graphene/contrib/django/fields.py
+++ b/graphene/contrib/django/fields.py
@@ -11,6 +11,7 @@ class DjangoConnectionField(ConnectionField):
 
     def __init__(self, *args, **kwargs):
         self.on = kwargs.pop('on', False)
+        kwargs['default'] = kwargs.pop('default', self.get_manager)
         return super(DjangoConnectionField, self).__init__(*args, **kwargs)
 
     @property
@@ -27,8 +28,6 @@ class DjangoConnectionField(ConnectionField):
         return resolved_qs
 
     def from_list(self, connection_type, resolved, args, info):
-        if resolved is None:
-            resolved = self.get_manager()
         resolved_qs = maybe_queryset(resolved)
         qs = self.get_queryset(resolved_qs, args, info)
         return super(DjangoConnectionField, self).from_list(connection_type, qs, args, info)

--- a/graphene/core/classtypes/objecttype.py
+++ b/graphene/core/classtypes/objecttype.py
@@ -42,18 +42,18 @@ class ObjectTypeMeta(FieldsClassTypeMeta):
 
 
 class ObjectType(six.with_metaclass(ObjectTypeMeta, FieldsClassType)):
-    _root = None
 
     class Meta:
         abstract = True
 
     def __getattr__(self, name):
-        print self._root
+        if name == '_root':
+            return
         return getattr(self._root, name)
 
     def __init__(self, *args, **kwargs):
-        self._root = kwargs.pop('_root', None)
         signals.pre_init.send(self.__class__, args=args, kwargs=kwargs)
+        self._root = kwargs.pop('_root', None)
         args_len = len(args)
         fields = self._meta.fields
         if args_len > len(fields):

--- a/graphene/core/classtypes/objecttype.py
+++ b/graphene/core/classtypes/objecttype.py
@@ -42,17 +42,18 @@ class ObjectTypeMeta(FieldsClassTypeMeta):
 
 
 class ObjectType(six.with_metaclass(ObjectTypeMeta, FieldsClassType)):
+    _root = None
 
     class Meta:
         abstract = True
 
     def __getattr__(self, name):
-        if name != '_root' and self._root:
-            return getattr(self._root, name)
+        print self._root
+        return getattr(self._root, name)
 
     def __init__(self, *args, **kwargs):
-        signals.pre_init.send(self.__class__, args=args, kwargs=kwargs)
         self._root = kwargs.pop('_root', None)
+        signals.pre_init.send(self.__class__, args=args, kwargs=kwargs)
         args_len = len(args)
         fields = self._meta.fields
         if args_len > len(fields):


### PR DESCRIPTION
This pull request set the default value in a `DjangoConnection` or `DjangoFilterConnection` to be a manager, so the resolve can actually return `None` or `[]` without any trouble.