### PR TITLE
Allow empty list in SQLAlchemyConnectionField.

### DIFF
--- a/graphene/contrib/sqlalchemy/fields.py
+++ b/graphene/contrib/sqlalchemy/fields.py
@@ -17,7 +17,7 @@ class SQLAlchemyConnectionField(ConnectionField):
         return self.type._meta.model
 
     def get_query(self, resolved_query, args, info):
-        return resolved_query or get_query(self.model, info)
+        return resolved_query if resolved_query is not None else get_query(self.model, info)
 
     def from_list(self, connection_type, resolved, args, info):
         query = self.get_query(resolved, args, info)


### PR DESCRIPTION
Custom resolve()'s empty list return value should take precedence over SQLAlchemyConnectionField default query.

I have the following:
     
    class Client(relay.Node):
        menuitems = SQLAlchemyConnectionField(MenuItem, connection_type=ProductsOnClient)
         def resolve_menuitems(self, args, info):
            return self.menu_items
 
Without this patch, if ``self.menu_items`` is an empty list, it will be ignored and I get items from other clients.