### PR TITLE
improve iso8601 handling

### DIFF
--- a/graphene/core/types/custom_scalars.py
+++ b/graphene/core/types/custom_scalars.py
@@ -1,5 +1,6 @@
 import datetime
 import json
+import iso8601
 
 from graphql.core.language import ast
 
@@ -33,9 +34,8 @@ class DateTime(Scalar):
     @staticmethod
     def parse_literal(node):
         if isinstance(node, ast.StringValue):
-            return datetime.datetime.strptime(
-                node.value, "%Y-%m-%dT%H:%M:%S.%f")
+            return iso8601.parse_date(node.value)
 
     @staticmethod
     def parse_value(value):
-        return datetime.datetime.strptime(value, "%Y-%m-%dT%H:%M:%S.%f")
+        return iso8601.parse_date(value)

--- a/graphene/core/types/custom_scalars.py
+++ b/graphene/core/types/custom_scalars.py
@@ -1,4 +1,3 @@
-import datetime
 import json
 import iso8601
 

--- a/graphene/core/types/tests/test_custom_scalars.py
+++ b/graphene/core/types/tests/test_custom_scalars.py
@@ -11,7 +11,7 @@ def test_date_time():
     def check_datetime(test_dt):
         assert test_dt.tzinfo == iso8601.UTC
         assert test_dt.year == 2016
-        assert test_dt.month == 04
+        assert test_dt.month == 4
         assert test_dt.day == 29
         assert test_dt.hour == 18
         assert test_dt.minute == 34

--- a/graphene/core/types/tests/test_custom_scalars.py
+++ b/graphene/core/types/tests/test_custom_scalars.py
@@ -1,0 +1,27 @@
+import iso8601
+
+from graphql.core.language.ast import StringValue
+
+from ..custom_scalars import DateTime
+
+def test_date_time():
+    test_iso_string = "2016-04-29T18:34:12.502Z"
+
+    def check_datetime(test_dt):
+        assert test_dt.tzinfo == iso8601.UTC
+        assert test_dt.year == 2016
+        assert test_dt.month == 04
+        assert test_dt.day == 29
+        assert test_dt.hour == 18
+        assert test_dt.minute == 34
+        assert test_dt.second == 12
+
+    test_dt = DateTime().parse_value(test_iso_string)
+    check_datetime(test_dt)
+
+    assert DateTime.serialize(test_dt) == "2016-04-29T18:34:12.502000+00:00"
+
+    node = StringValue(test_iso_string)
+    test_dt = DateTime.parse_literal(node)
+    check_datetime(test_dt)
+

--- a/graphene/core/types/tests/test_custom_scalars.py
+++ b/graphene/core/types/tests/test_custom_scalars.py
@@ -4,8 +4,10 @@ from graphql.core.language.ast import StringValue
 
 from ..custom_scalars import DateTime
 
+
 def test_date_time():
     test_iso_string = "2016-04-29T18:34:12.502Z"
+
 
     def check_datetime(test_dt):
         assert test_dt.tzinfo == iso8601.UTC
@@ -24,4 +26,3 @@ def test_date_time():
     node = StringValue(test_iso_string)
     test_dt = DateTime.parse_literal(node)
     check_datetime(test_dt)
-

--- a/graphene/core/types/tests/test_custom_scalars.py
+++ b/graphene/core/types/tests/test_custom_scalars.py
@@ -8,7 +8,6 @@ from ..custom_scalars import DateTime
 def test_date_time():
     test_iso_string = "2016-04-29T18:34:12.502Z"
 
-
     def check_datetime(test_dt):
         assert test_dt.tzinfo == iso8601.UTC
         assert test_dt.year == 2016

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,7 @@ setup(
         'six>=1.10.0',
         'graphql-core>=0.4.9',
         'graphql-relay==0.3.3',
+        'iso8601==0.1.11',
     ],
     tests_require=[
         'django-filter>=0.10.0',

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
         'six>=1.10.0',
         'graphql-core>=0.4.9',
         'graphql-relay==0.3.3',
-        'iso8601==0.1.11',
+        'iso8601',
     ],
     tests_require=[
         'django-filter>=0.10.0',


### PR DESCRIPTION
The DateTime scalar accepts only a small portion of valid ISO8601 date time strings.  This pull request uses the iso8601 library to improve that.

As an example here's a Date created in node.js and rendered as an ISO8601 string:

```js
> var d = new Date()
Fri Apr 29 2016 13:34:12 GMT-0500 (CDT)
> d.toISOString()
'2016-04-29T18:34:12.502Z'
```

This fails with the old parsing method:

```python 
import datetime
iso_from_node = '2016-04-29T18:34:12.502Z'
# this line is copied from the old parsing code
datetime.datetime.strptime(iso_from_node, "%Y-%m-%dT%H:%M:%S.%f")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/_strptime.py", line 328, in _strptime
    data_string[found.end():])
ValueError: unconverted data remains: Z

import iso8601
iso8601.parse_date(iso_from_node)
datetime.datetime(2016, 4, 29, 18, 34, 12, 502000, tzinfo=<iso8601.Utc>)
```

I have included tests as well.  I wasn't able to run the full test suite because following the instructions in the README.md file didn't work in a fresh virtualenv didn't work.  I suspect it can be made to work but I don't have the time right this moment.