### PR TITLE
Updated references/imports for latest version graphql-core

### DIFF
--- a/graphene/contrib/django/tests/test_types.py
+++ b/graphene/contrib/django/tests/test_types.py
@@ -1,4 +1,4 @@
-from graphql.core.type import GraphQLObjectType
+from graphql.type import GraphQLObjectType
 from mock import patch
 
 from graphene import Schema

--- a/graphene/contrib/sqlalchemy/tests/test_types.py
+++ b/graphene/contrib/sqlalchemy/tests/test_types.py
@@ -1,4 +1,4 @@
-from graphql.core.type import GraphQLObjectType
+from graphql.type import GraphQLObjectType
 from pytest import raises
 
 from graphene import Schema

--- a/graphene/core/classtypes/enum.py
+++ b/graphene/core/classtypes/enum.py
@@ -1,5 +1,5 @@
 import six
-from graphql.core.type import GraphQLEnumType, GraphQLEnumValue
+from graphql.type import GraphQLEnumType, GraphQLEnumValue
 
 from .base import ClassTypeMeta, ClassType
 from ..types.base import MountedType

--- a/graphene/core/classtypes/inputobjecttype.py
+++ b/graphene/core/classtypes/inputobjecttype.py
@@ -1,6 +1,6 @@
 from functools import partial
 
-from graphql.core.type import GraphQLInputObjectType
+from graphql.type import GraphQLInputObjectType
 
 from .base import FieldsClassType
 

--- a/graphene/core/classtypes/interface.py
+++ b/graphene/core/classtypes/interface.py
@@ -1,7 +1,7 @@
 from functools import partial
 
 import six
-from graphql.core.type import GraphQLInterfaceType
+from graphql.type import GraphQLInterfaceType
 
 from .base import FieldsClassTypeMeta
 from .objecttype import ObjectType, ObjectTypeMeta

--- a/graphene/core/classtypes/objecttype.py
+++ b/graphene/core/classtypes/objecttype.py
@@ -1,7 +1,7 @@
 from functools import partial
 
 import six
-from graphql.core.type import GraphQLObjectType
+from graphql.type import GraphQLObjectType
 
 from graphene import signals
 

--- a/graphene/core/classtypes/scalar.py
+++ b/graphene/core/classtypes/scalar.py
@@ -1,4 +1,4 @@
-from graphql.core.type import GraphQLScalarType
+from graphql.type import GraphQLScalarType
 
 from ..types.base import MountedType
 from .base import ClassType

--- a/graphene/core/classtypes/tests/test_enum.py
+++ b/graphene/core/classtypes/tests/test_enum.py
@@ -1,4 +1,4 @@
-from graphql.core.type import GraphQLEnumType
+from graphql.type import GraphQLEnumType
 
 from graphene.core.schema import Schema
 

--- a/graphene/core/classtypes/tests/test_inputobjecttype.py
+++ b/graphene/core/classtypes/tests/test_inputobjecttype.py
@@ -1,5 +1,5 @@
 
-from graphql.core.type import GraphQLInputObjectType
+from graphql.type import GraphQLInputObjectType
 
 from graphene.core.schema import Schema
 from graphene.core.types import String

--- a/graphene/core/classtypes/tests/test_interface.py
+++ b/graphene/core/classtypes/tests/test_interface.py
@@ -1,4 +1,4 @@
-from graphql.core.type import GraphQLInterfaceType, GraphQLObjectType
+from graphql.type import GraphQLInterfaceType, GraphQLObjectType
 from py.test import raises
 
 from graphene.core.schema import Schema

--- a/graphene/core/classtypes/tests/test_mutation.py
+++ b/graphene/core/classtypes/tests/test_mutation.py
@@ -1,5 +1,5 @@
 
-from graphql.core.type import GraphQLObjectType
+from graphql.type import GraphQLObjectType
 
 from graphene.core.schema import Schema
 from graphene.core.types import String

--- a/graphene/core/classtypes/tests/test_objecttype.py
+++ b/graphene/core/classtypes/tests/test_objecttype.py
@@ -1,4 +1,4 @@
-from graphql.core.type import GraphQLObjectType
+from graphql.type import GraphQLObjectType
 from py.test import raises
 
 from graphene.core.schema import Schema

--- a/graphene/core/classtypes/tests/test_scalar.py
+++ b/graphene/core/classtypes/tests/test_scalar.py
@@ -1,4 +1,4 @@
-from graphql.core.type import GraphQLScalarType
+from graphql.type import GraphQLScalarType
 
 from ...schema import Schema
 from ..scalar import Scalar
@@ -6,7 +6,7 @@ from ..scalar import Scalar
 
 def test_custom_scalar():
     import datetime
-    from graphql.core.language import ast
+    from graphql.language import ast
 
     class DateTimeScalar(Scalar):
         '''DateTimeScalar Documentation'''

--- a/graphene/core/classtypes/tests/test_uniontype.py
+++ b/graphene/core/classtypes/tests/test_uniontype.py
@@ -1,4 +1,4 @@
-from graphql.core.type import GraphQLUnionType
+from graphql.type import GraphQLUnionType
 
 from graphene.core.schema import Schema
 from graphene.core.types import String

--- a/graphene/core/classtypes/uniontype.py
+++ b/graphene/core/classtypes/uniontype.py
@@ -1,7 +1,7 @@
 from functools import partial
 
 import six
-from graphql.core.type import GraphQLUnionType
+from graphql.type import GraphQLUnionType
 
 from .base import FieldsClassType, FieldsClassTypeMeta, FieldsOptions
 

--- a/graphene/core/schema.py
+++ b/graphene/core/schema.py
@@ -66,8 +66,6 @@ class Schema(object):
 
     @property
     def executor(self):
-        if not self._executor:
-            self._executor = SyncExecutor()
         return self._executor
 
     @executor.setter

--- a/graphene/core/schema.py
+++ b/graphene/core/schema.py
@@ -1,12 +1,10 @@
 import inspect
 from collections import OrderedDict
 
-from graphql.core.execution.executor import Executor
-from graphql.core.execution.middlewares.sync import \
-    SynchronousExecutionMiddleware
-from graphql.core.type import GraphQLSchema as _GraphQLSchema
-from graphql.core.utils.introspection_query import introspection_query
-from graphql.core.utils.schema_printer import print_schema
+from graphql.execution.executors.sync import SyncExecutor
+from graphql.type import GraphQLSchema as _GraphQLSchema
+from graphql.utils.introspection_query import introspection_query
+from graphql.utils.schema_printer import print_schema
 
 from graphene import signals
 

--- a/graphene/core/schema.py
+++ b/graphene/core/schema.py
@@ -67,8 +67,7 @@ class Schema(object):
     @property
     def executor(self):
         if not self._executor:
-            self._executor = Executor(
-                [SynchronousExecutionMiddleware()], map_type=OrderedDict)
+            self._executor = SyncExecutor()
         return self._executor
 
     @executor.setter

--- a/graphene/core/tests/test_old_fields.py
+++ b/graphene/core/tests/test_old_fields.py
@@ -1,4 +1,4 @@
-from graphql.core.type import (GraphQLBoolean, GraphQLField, GraphQLFloat,
+from graphql.type import (GraphQLBoolean, GraphQLField, GraphQLFloat,
                                GraphQLID, GraphQLInt, GraphQLNonNull,
                                GraphQLString)
 from py.test import raises

--- a/graphene/core/tests/test_query.py
+++ b/graphene/core/tests/test_query.py
@@ -1,7 +1,7 @@
 
 
-from graphql.core import graphql
-from graphql.core.type import GraphQLSchema
+from graphql import graphql
+from graphql.type import GraphQLSchema
 
 from graphene.core.fields import Field
 from graphene.core.schema import Schema

--- a/graphene/core/tests/test_schema.py
+++ b/graphene/core/tests/test_schema.py
@@ -1,4 +1,4 @@
-from graphql.core import graphql
+from graphql import graphql
 from py.test import raises
 
 from graphene import Interface, List, ObjectType, Schema, String

--- a/graphene/core/types/argument.py
+++ b/graphene/core/types/argument.py
@@ -1,7 +1,7 @@
 from functools import wraps
 from itertools import chain
 
-from graphql.core.type import GraphQLArgument
+from graphql.type import GraphQLArgument
 
 from ...utils import ProxySnakeDict
 from .base import ArgumentType, GroupNamedType, NamedType, OrderedType

--- a/graphene/core/types/custom_scalars.py
+++ b/graphene/core/types/custom_scalars.py
@@ -1,7 +1,7 @@
 import json
 import iso8601
 
-from graphql.core.language import ast
+from graphql.language import ast
 
 from ...core.classtypes.scalar import Scalar
 

--- a/graphene/core/types/definitions.py
+++ b/graphene/core/types/definitions.py
@@ -1,5 +1,5 @@
 import six
-from graphql.core.type import GraphQLList, GraphQLNonNull
+from graphql.type import GraphQLList, GraphQLNonNull
 
 from .base import LazyType, MountedType, MountType
 

--- a/graphene/core/types/field.py
+++ b/graphene/core/types/field.py
@@ -2,7 +2,7 @@ from collections import OrderedDict
 from functools import wraps
 
 import six
-from graphql.core.type import GraphQLField, GraphQLInputObjectField
+from graphql.type import GraphQLField, GraphQLInputObjectField
 
 from ...utils import maybe_func
 from ..classtypes.base import FieldsClassType

--- a/graphene/core/types/scalars.py
+++ b/graphene/core/types/scalars.py
@@ -1,4 +1,4 @@
-from graphql.core.type import (GraphQLBoolean, GraphQLFloat, GraphQLID,
+from graphql.type import (GraphQLBoolean, GraphQLFloat, GraphQLID,
                                GraphQLInt, GraphQLString)
 
 from .base import MountedType

--- a/graphene/core/types/tests/test_argument.py
+++ b/graphene/core/types/tests/test_argument.py
@@ -1,4 +1,4 @@
-from graphql.core.type import GraphQLArgument
+from graphql.type import GraphQLArgument
 from pytest import raises
 
 from graphene.core.schema import Schema

--- a/graphene/core/types/tests/test_custom_scalars.py
+++ b/graphene/core/types/tests/test_custom_scalars.py
@@ -1,6 +1,6 @@
 import iso8601
 
-from graphql.core.language.ast import StringValue
+from graphql.language.ast import StringValue
 
 from ..custom_scalars import DateTime
 

--- a/graphene/core/types/tests/test_definitions.py
+++ b/graphene/core/types/tests/test_definitions.py
@@ -1,4 +1,4 @@
-from graphql.core.type import GraphQLList, GraphQLNonNull, GraphQLString
+from graphql.type import GraphQLList, GraphQLNonNull, GraphQLString
 
 from graphene.core.schema import Schema
 

--- a/graphene/core/types/tests/test_field.py
+++ b/graphene/core/types/tests/test_field.py
@@ -1,4 +1,4 @@
-from graphql.core.type import (GraphQLField, GraphQLInputObjectField,
+from graphql.type import (GraphQLField, GraphQLInputObjectField,
                                GraphQLString)
 
 from graphene.core.schema import Schema

--- a/graphene/core/types/tests/test_scalars.py
+++ b/graphene/core/types/tests/test_scalars.py
@@ -1,4 +1,4 @@
-from graphql.core.type import (GraphQLBoolean, GraphQLFloat, GraphQLID,
+from graphql.type import (GraphQLBoolean, GraphQLFloat, GraphQLID,
                                GraphQLInt, GraphQLString)
 
 from graphene.core.schema import Schema

--- a/graphene/relay/tests/test_mutations.py
+++ b/graphene/relay/tests/test_mutations.py
@@ -1,4 +1,4 @@
-from graphql.core.type import GraphQLInputObjectField
+from graphql.type import GraphQLInputObjectField
 
 import graphene
 from graphene import relay

--- a/graphene/relay/tests/test_query.py
+++ b/graphene/relay/tests/test_query.py
@@ -1,5 +1,5 @@
 import pytest
-from graphql.core.type import GraphQLID, GraphQLNonNull
+from graphql.type import GraphQLID, GraphQLNonNull
 
 import graphene
 from graphene import relay

--- a/graphene/relay/tests/test_types.py
+++ b/graphene/relay/tests/test_types.py
@@ -1,4 +1,4 @@
-from graphql.core.type import GraphQLList
+from graphql.type import GraphQLList
 from pytest import raises
 
 import graphene

--- a/graphene/utils/misc.py
+++ b/graphene/utils/misc.py
@@ -1,6 +1,6 @@
 from collections import OrderedDict
 
-from graphql.core.type import GraphQLEnumType, GraphQLEnumValue
+from graphql.type import GraphQLEnumType, GraphQLEnumValue
 
 
 def enum_to_graphql_enum(enumeration):

--- a/graphene/utils/tests/test_misc.py
+++ b/graphene/utils/tests/test_misc.py
@@ -1,6 +1,6 @@
 import collections
 
-from graphql.core.type import GraphQLEnumType
+from graphql.type import GraphQLEnumType
 
 from ..misc import enum_to_graphql_enum
 

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
 
     install_requires=[
         'six>=1.10.0',
-        'graphql-core>=0.4.9',
+        'graphql-core>=0.5.0',
         'graphql-relay==0.3.3',
         'iso8601',
     ],

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ class PyTest(TestCommand):
 
 setup(
     name='graphene',
-    version='0.8.1',
+    version='0.8.2',
 
     description='GraphQL Framework for Python',
     long_description=open('README.rst').read(),


### PR DESCRIPTION
@syrusakbary: as I mentioned in slack, this PR updates the references/imports of `graphql-core` to accommodate the new api. 

Unfortunately, I'm having difficulty running the test suite (I think it's related to the version downloaded when the tests run). I will try to figure out the problem later today when I get some downtime. 