### PR TITLE
Fixed bug when no middlewares are present

### DIFF
--- a/graphene/core/tests/test_schema.py
+++ b/graphene/core/tests/test_schema.py
@@ -119,6 +119,7 @@ def test_auto_camelcase_off():
     assert not result.errors
     assert result.data == expected
 
+
 def test_schema_register():
     schema = Schema(name='My own schema')
 

--- a/graphene/core/tests/test_schema.py
+++ b/graphene/core/tests/test_schema.py
@@ -104,6 +104,21 @@ def test_schema_no_query():
     assert 'define a base query type' in str(excinfo)
 
 
+def test_auto_camelcase_off():
+    schema = Schema(name='My own schema', auto_camelcase=False)
+
+    class Query(ObjectType):
+        test_field = String(resolver=lambda *_: 'Dog')
+
+    schema.query = Query
+
+    query = "query {test_field}"
+    expected = {"test_field": "Dog"}
+
+    result = graphql(schema.schema, query, root_value=Query(object()))
+    assert not result.errors
+    assert result.data == expected
+
 def test_schema_register():
     schema = Schema(name='My own schema')
 

--- a/graphene/core/types/base.py
+++ b/graphene/core/types/base.py
@@ -147,6 +147,8 @@ class GroupNamedType(InstanceType):
         name = type.name
         if not name and schema.auto_camelcase:
             name = to_camel_case(type.default_name)
+        elif not name:
+            name = type.default_name
         return name, schema.T(type)
 
     def iter_types(self, schema):


### PR DESCRIPTION
I ran into an issue with schemas when `auto_camelcase` was set to `False` and no middlewares were set on the resolver. This resulted in an unnamed field which could not be executed.