### PR TITLE
Add test for django grouped choices

### DIFF
--- a/graphene/contrib/django/tests/test_converter.py
+++ b/graphene/contrib/django/tests/test_converter.py
@@ -117,6 +117,23 @@ def test_field_with_choices_convert_enum():
     assert graphene_type.__enum__.__members__['ENGLISH'].value == 'en'
 
 
+def test_field_with_grouped_choices():
+    field = models.CharField(help_text='Language', choices=(
+        ('Europe', (
+            ('es', 'Spanish'),
+            ('en', 'English'),
+        )),
+    ))
+
+    class TranslatedModel(models.Model):
+        language = field
+
+        class Meta:
+            app_label = 'test'
+
+    convert_django_field_with_choices(field)
+
+
 def test_should_float_convert_float():
     assert_conversion(models.FloatField, graphene.Float)
 


### PR DESCRIPTION
It is a standard pattern in Django to group display values in [field `choices`](https://docs.djangoproject.com/en/1.9/ref/models/fields/#choices).

Graphene should support this.