### PR TITLE
Add test for choices with duplicate display values

### DIFF
--- a/graphene/contrib/django/tests/test_converter.py
+++ b/graphene/contrib/django/tests/test_converter.py
@@ -117,6 +117,21 @@ def test_field_with_choices_convert_enum():
     assert graphene_type.__enum__.__members__['ENGLISH'].value == 'en'
 
 
+def test_field_with_choices_duplicate_display_value():
+    field = models.CharField(help_text='Language', choices=(
+        ('es', 'Spanish'),
+        ('en', 'Spanish')
+    ))
+
+    class TranslatedModel(models.Model):
+        language = field
+
+        class Meta:
+            app_label = 'test'
+
+    convert_django_field_with_choices(field)
+
+
 def test_should_float_convert_float():
     assert_conversion(models.FloatField, graphene.Float)
 


### PR DESCRIPTION
Graphene fails in a not very helpful way if a django field with `choices` has duplicate display values.

I see two options here:
- forbid this, and raise a nicer exception
- allow this

I prefer the second option for consistency with django forms (which don't care). It is also potentially desirable when used with grouped choices (#185).
