### PR TITLE
Fix ugettext_lazy objects in Choice tuples not being evaluated.

### DIFF
--- a/graphene/contrib/django/tests/models.py
+++ b/graphene/contrib/django/tests/models.py
@@ -1,6 +1,12 @@
 from __future__ import absolute_import
 
 from django.db import models
+from django.utils.translation import ugettext_lazy as _
+
+CHOICES = (
+    (1, 'this'),
+    (2, _('that'))
+)
 
 
 class Pet(models.Model):
@@ -22,6 +28,7 @@ class Reporter(models.Model):
     last_name = models.CharField(max_length=30)
     email = models.EmailField()
     pets = models.ManyToManyField('self')
+    a_choice = models.CharField(max_length=30, choices=CHOICES)
 
     def __str__(self):              # __unicode__ on Python 2
         return "%s %s" % (self.first_name, self.last_name)

--- a/graphene/utils/str_converters.py
+++ b/graphene/utils/str_converters.py
@@ -18,4 +18,4 @@ def to_snake_case(name):
 
 
 def to_const(string):
-    return re.sub('[\W|^]+', '_', string).upper()
+    return re.sub('[\W|^]+', '_', string.format()).upper()


### PR DESCRIPTION
When you have a translation string in a choice iterable, like this:

```py
CHOICES = (
    (1, _('string to be translated')),
)

class Foo(models.Model):
    bar = models.CharField(max_length=100, choices=CHOICES)
```

Graphene will fail because it passes the ugettextlazy object to ```re.sub()```. 

```
  File "/usr/local/lib/python2.7/dist-packages/graphene/contrib/django/types.py", line 32, in construct_fields
    converted_field = convert_django_field_with_choices(field)
  File "/usr/local/lib/python2.7/dist-packages/graphene/contrib/django/converter.py", line 25, in convert_django_field_with_choices
    return Enum(name.upper(), list(convert_choices(choices)), description=field.help_text)
  File "/usr/local/lib/python2.7/dist-packages/graphene/contrib/django/converter.py", line 17, in convert_choices
    yield to_const(name), value
  File "/usr/local/lib/python2.7/dist-packages/graphene/utils/str_converters.py", line 21, in to_const
    return re.sub('[\W|^]+', '_', string).upper()
  File "/usr/lib/python2.7/re.py", line 155, in sub
    return _compile(pattern, flags).sub(repl, string, count)
TypeError: Error when calling the metaclass bases
    expected string or buffer
```

This pull request solves that by always calling ```string.format()``` before passing it to the regex. Either its a string and nothing will happen (since we don't pass any arguments to ```.format()```), or its a ugettextlazy object and it will return the desired string.

This solution works, but I'm not sure if its optimal? Feedback is welcome :)