### PR TITLE
Added SimpleConnection to relay types

### DIFF
--- a/graphene/relay/__init__.py
+++ b/graphene/relay/__init__.py
@@ -16,4 +16,4 @@ from .types import (
 from .utils import is_node
 
 __all__ = ['ConnectionField', 'NodeField', 'GlobalIDField', 'Node',
-           'PageInfo', 'Edge', 'Connection', 'ClientIDMutation', 'is_node']
+           'PageInfo', 'Edge', 'Connection', 'SimpleConnection', 'ClientIDMutation', 'is_node']

--- a/graphene/relay/__init__.py
+++ b/graphene/relay/__init__.py
@@ -9,6 +9,7 @@ from .types import (
     PageInfo,
     Edge,
     Connection,
+    SimpleConnection
     ClientIDMutation
 )
 

--- a/graphene/relay/__init__.py
+++ b/graphene/relay/__init__.py
@@ -9,8 +9,8 @@ from .types import (
     PageInfo,
     Edge,
     Connection,
-    SimpleConnection
-    ClientIDMutation
+    SimpleConnection,
+    ClientIDMutation,
 )
 
 from .utils import is_node

--- a/graphene/relay/fields.py
+++ b/graphene/relay/fields.py
@@ -46,6 +46,10 @@ class ConnectionField(Field):
 
     def get_connection_type(self, node):
         connection_type = self.connection_type or node.get_connection_type()
+        
+        if issubclass(connection_type, SimpleConnection):
+            return connection_type.for_node(node)
+        
         edge_type = self.get_edge_type(node)
         return connection_type.for_node(node, edge_type=edge_type)
 
@@ -105,3 +109,5 @@ class GlobalIDField(Field):
 
     def resolver(self, instance, args, info):
         return instance.to_global_id()
+
+from .types import SimpleConnection

--- a/graphene/relay/fields.py
+++ b/graphene/relay/fields.py
@@ -58,10 +58,10 @@ class ConnectionField(Field):
         return edge_type.for_node(node)
 
     def get_type(self, schema):
-        from graphene.relay.utils import is_node
+        from graphene.relay.utils import is_node, is_node_type
         type = schema.T(self.type)
         node = schema.objecttype(type)
-        assert is_node(node), 'Only nodes have connections.'
+        assert is_node(node) or is_node_type(node), 'Only nodes have connections.'
         schema.register(node)
         connection_type = self.get_connection_type(node)
 

--- a/graphene/relay/fields.py
+++ b/graphene/relay/fields.py
@@ -46,10 +46,10 @@ class ConnectionField(Field):
 
     def get_connection_type(self, node):
         connection_type = self.connection_type or node.get_connection_type()
-        
+
         if issubclass(connection_type, SimpleConnection):
             return connection_type.for_node(node)
-        
+
         edge_type = self.get_edge_type(node)
         return connection_type.for_node(node, edge_type=edge_type)
 

--- a/graphene/relay/types.py
+++ b/graphene/relay/types.py
@@ -113,13 +113,12 @@ class SimpleConnection(Connection):
     @memoize
     def for_node(cls, node, edge_type=None):
         from graphene.relay.utils import is_node
-        edge_type = edge_type or node
         assert is_node(node), 'ObjectTypes in a connection have to be Nodes'
-        edges = List(edge_type, description='Information to aid in pagination.')
+        edges = List(node, description='Information to aid in pagination.')
         return type(
             '%s%s' % (node._meta.type_name, cls._meta.type_name),
             (cls,),
-            {'edge_type': edge_type, 'edges': edges})
+            {'edge_type': node, 'edges': edges})
 
     @classmethod
     def from_list(cls, iterable, args, context, info):

--- a/graphene/relay/types.py
+++ b/graphene/relay/types.py
@@ -112,8 +112,8 @@ class SimpleConnection(Connection):
     @classmethod
     @memoize
     def for_node(cls, node, edge_type=None):
-        from graphene.relay.utils import is_node
-        assert is_node(node), 'ObjectTypes in a connection have to be Nodes'
+        from graphene.relay.utils import is_node, is_node_type
+        assert is_node(node) or is_node_type(node), 'ObjectTypes in a connection have to be Nodes'
         edges = List(node, description='Information to aid in pagination.')
         return type(
             '%s%s' % (node._meta.type_name, cls._meta.type_name),

--- a/graphene/relay/types.py
+++ b/graphene/relay/types.py
@@ -77,7 +77,7 @@ class Connection(ObjectType):
     @classmethod
     @memoize
     def for_node(cls, node, edge_type=None, root_values=None):
-        from graphene.relay.utils import is_node
+        from graphene.relay.utils import is_node, is_node_type
         edge_type = edge_type or Edge.for_node(node)
         assert is_node(node) or is_node_type(node), 'ObjectTypes in a connection have to be Nodes'
         edges = List(edge_type, description='Information to aid in pagination.')

--- a/graphene/relay/types.py
+++ b/graphene/relay/types.py
@@ -49,8 +49,8 @@ class Edge(ObjectType):
     @classmethod
     @memoize
     def for_node(cls, node):
-        from graphene.relay.utils import is_node
-        assert is_node(node), 'ObjectTypes in a edge have to be Nodes'
+        from graphene.relay.utils import is_node, is_node_type
+        assert is_node(node) or is_node_type(node), 'ObjectTypes in a edge have to be Nodes'
         node_field = Field(node, description='The item at the end of the edge')
         return type(
             '%s%s' % (node._meta.type_name, cls._meta.type_name),

--- a/graphene/relay/types.py
+++ b/graphene/relay/types.py
@@ -76,15 +76,15 @@ class Connection(ObjectType):
 
     @classmethod
     @memoize
-    def for_node(cls, node, edge_type=None):
+    def for_node(cls, node, edge_type=None, root_values=None):
         from graphene.relay.utils import is_node
         edge_type = edge_type or Edge.for_node(node)
-        assert is_node(node), 'ObjectTypes in a connection have to be Nodes'
+        assert is_node(node) or is_node_type(node), 'ObjectTypes in a connection have to be Nodes'
         edges = List(edge_type, description='Information to aid in pagination.')
         return type(
             '%s%s' % (node._meta.type_name, cls._meta.type_name),
             (cls,),
-            {'edge_type': edge_type, 'edges': edges})
+            {'edge_type': edge_type, 'edges': edges, '_root': root_values})
 
     @classmethod
     def from_list(cls, iterable, args, context, info):

--- a/graphene/relay/types.py
+++ b/graphene/relay/types.py
@@ -111,14 +111,14 @@ class SimpleConnection(Connection):
 
     @classmethod
     @memoize
-    def for_node(cls, node, edge_type=None):
+    def for_node(cls, node, root_values=None):
         from graphene.relay.utils import is_node, is_node_type
         assert is_node(node) or is_node_type(node), 'ObjectTypes in a connection have to be Nodes'
         edges = List(node, description='Information to aid in pagination.')
         return type(
             '%s%s' % (node._meta.type_name, cls._meta.type_name),
             (cls,),
-            {'edge_type': node, 'edges': edges})
+            {'edge_type': node, 'edges': edges, '_root': root_values})
 
     @classmethod
     def from_list(cls, iterable, args, context, info):


### PR DESCRIPTION
Sometimes you do not want a full blown relay connection, where you have `edges[...].node.attribute` but simply `edges[...].attribute`. According to https://github.com/graphql/graphql-relay-js/issues/27#issuecomment-142421989 relay has support for this simpler use-case as well if you do not need certain functionality such as deletion. This implements such a type that can be used instead of the default connection via the `connection_type` argument on `ConnectionField`

This is dependent on https://github.com/graphql-python/graphql-relay-py/pull/6