### PR TITLE
If node type_name is in connection type_name use connection type_name

### DIFF
--- a/graphene/relay/types.py
+++ b/graphene/relay/types.py
@@ -81,8 +81,11 @@ class Connection(ObjectType):
         edge_type = edge_type or Edge.for_node(node)
         assert is_node(node), 'ObjectTypes in a connection have to be Nodes'
         edges = List(edge_type, description='Information to aid in pagination.')
+        connection_name = (cls._meta.type_name
+                           if node._meta.type_name.lower() in cls._meta.type_name.lower()
+                           else '%s%s' % (node._meta.type_name, cls._meta.type_name))
         return type(
-            '%s%s' % (node._meta.type_name, cls._meta.type_name),
+            connection_name,
             (cls,),
             {'edge_type': edge_type, 'edges': edges})
 


### PR DESCRIPTION
Let's say we have a node `Holdings` and then make a custom connection `HoldingConnection` that subclasses from `relay.Connection` it would then be of type `HoldingHoldingConnection`. This way we only take the connection name and don't have these redundant type names (which can become quite apparent when using relay)
