### PR TITLE
fixed model column name [sqlalchemy]

### DIFF
--- a/graphene/contrib/sqlalchemy/types.py
+++ b/graphene/contrib/sqlalchemy/types.py
@@ -33,16 +33,16 @@ class SQLAlchemyObjectTypeMeta(ObjectTypeMeta):
             converted_relationship = convert_sqlalchemy_relationship(relationship)
             cls.add_to_class(relationship.key, converted_relationship)
 
-        for column in inspected_model.columns:
-            is_not_in_only = only_fields and column.name not in only_fields
-            is_already_created = column.name in already_created_fields
-            is_excluded = column.name in exclude_fields or is_already_created
+        for name, column in inspected_model.columns.items():
+            is_not_in_only = only_fields and name not in only_fields
+            is_already_created = name in already_created_fields
+            is_excluded = name in exclude_fields or is_already_created
             if is_not_in_only or is_excluded:
                 # We skip this field if we specify only_fields and is not
                 # in there. Or when we excldue this field in exclude_fields
                 continue
             converted_column = convert_sqlalchemy_column(column)
-            cls.add_to_class(column.name, converted_column)
+            cls.add_to_class(name, converted_column)
 
     def construct(cls, *args, **kwargs):
         cls = super(SQLAlchemyObjectTypeMeta, cls).construct(*args, **kwargs)


### PR DESCRIPTION
I have existing db and create User model for that db using automap_base
```python
import os

from sqlalchemy.ext.automap import automap_base
from sqlalchemy.orm import Session
from sqlalchemy import create_engine, Column, Integer, String, ForeignKey

Base = automap_base()
class User(Base):
    __tablename__ = 'users'
    id = Column(Integer, primary_key=True)
    email = Column('mail', String(100))
    password = Column('pass', String(32))

engine = create_engine(os.getenv('DATABASE_URI'))
# reflect the tables
Base.prepare(engine, reflect=True)
```

but if I use query for users
```
query {
  users {
    edges {
      node {
        about
        email
        password
      }
    }
  }
}
```
fields `email` and `password` doesn't exists because these fields are redefined in the model