### PR TITLE
Add postgresql dialects for sqlachemy

### DIFF
--- a/examples/flask_sqlalchemy/app.py
+++ b/examples/flask_sqlalchemy/app.py
@@ -1,7 +1,7 @@
 from flask import Flask
 
 from database import db_session, init_db
-from flask_graphql import GraphQL
+from flask_graphql import GraphQLView
 from schema import schema
 
 app = Flask(__name__)
@@ -27,7 +27,7 @@ default_query = '''
   }
 }'''.strip()
 
-GraphQL(app, schema=schema, default_query=default_query)
+app.add_url_rule('/graphql', view_func=GraphQLView.as_view('graphql', schema=schema, graphiql=True))
 
 
 @app.teardown_appcontext

--- a/examples/flask_sqlalchemy/database.py
+++ b/examples/flask_sqlalchemy/database.py
@@ -34,5 +34,12 @@ def init_db():
     roy = Employee(name='Roy', department=engineering, role=engineer)
     db_session.add(roy)
     tracy = Employee(name='Tracy', department=hr, role=manager)
+
+    # postgresql specific dialects tests
+    # tracy.articles = [1, 2, 3, 4]
+    # tracy.json_data = {"test_json": "test_json"}
+    # tracy.jsonb_data = {"test_jsonb": "test_jsonb"}
+    # tracy.hstore_data = {"test_hstore": "test_hstore"}
+
     db_session.add(tracy)
     db_session.commit()

--- a/examples/flask_sqlalchemy/models.py
+++ b/examples/flask_sqlalchemy/models.py
@@ -1,4 +1,8 @@
+import uuid
+
 from sqlalchemy import Column, DateTime, ForeignKey, Integer, String, func
+from sqlalchemy.dialects.postgresql import UUID, ENUM, JSON, JSONB, HSTORE, ARRAY
+from sqlalchemy.sql.expression import text
 from sqlalchemy.orm import backref, relationship
 
 from database import Base
@@ -26,6 +30,15 @@ class Employee(Base):
     hired_on = Column(DateTime, default=func.now())
     department_id = Column(Integer, ForeignKey('department.id'))
     role_id = Column(Integer, ForeignKey('roles.role_id'))
+
+    # Uncomment below for postgresql specific fields testing
+    # uuid = Column(UUID(), server_default=text("uuid_generate_v4()"))
+    # is_active = Column(ENUM('Yes', 'No', name='is_active'), default="Yes")
+    # json_data = Column(JSON())
+    # jsonb_data = Column(JSONB())
+    # hstore_data = Column(HSTORE())
+    # articles = Column(ARRAY(Integer))
+
     # Use cascade='delete,all' to propagate the deletion of a Department onto its Employees
     department = relationship(
         Department,

--- a/examples/flask_sqlalchemy/models.py
+++ b/examples/flask_sqlalchemy/models.py
@@ -1,9 +1,10 @@
-import uuid
-
 from sqlalchemy import Column, DateTime, ForeignKey, Integer, String, func
-from sqlalchemy.dialects.postgresql import UUID, ENUM, JSON, JSONB, HSTORE, ARRAY
-from sqlalchemy.sql.expression import text
 from sqlalchemy.orm import backref, relationship
+
+# Uncomment import below for postgresql tests
+# import uuid
+# from sqlalchemy.dialects.postgresql import UUID, ENUM, JSON, JSONB, HSTORE, ARRAY
+# from sqlalchemy.sql.expression import text
 
 from database import Base
 

--- a/graphene/contrib/sqlalchemy/converter.py
+++ b/graphene/contrib/sqlalchemy/converter.py
@@ -80,7 +80,8 @@ def convert_column_to_enum(type, column):
 
 @convert_sqlalchemy_type.register(postgresql.ARRAY)
 def convert_postgres_array_to_list(type, column):
-    return List(description=column.doc)
+    graphene_type = convert_sqlalchemy_type(column.type.item_type, column)
+    return List(graphene_type, description=column.doc)
 
 
 @convert_sqlalchemy_type.register(postgresql.HSTORE)

--- a/graphene/contrib/sqlalchemy/tests/test_converter.py
+++ b/graphene/contrib/sqlalchemy/tests/test_converter.py
@@ -2,8 +2,10 @@ from py.test import raises
 from sqlalchemy import Column, Table, types
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy_utils.types.choice import ChoiceType
+from sqlalchemy.dialects import postgresql
 
 import graphene
+from graphene.core.types.custom_scalars import JSONString
 from graphene.contrib.sqlalchemy.converter import (convert_sqlalchemy_column,
                                                    convert_sqlalchemy_relationship)
 from graphene.contrib.sqlalchemy.fields import (ConnectionOrListField,
@@ -122,3 +124,27 @@ def test_should_onetomany_convert_model():
     assert isinstance(graphene_type, ConnectionOrListField)
     assert isinstance(graphene_type.type, SQLAlchemyModelField)
     assert graphene_type.type.model == Article
+
+
+def test_should_postgresql_uuid_convert():
+    assert_column_conversion(postgresql.UUID(), graphene.String)
+
+
+def test_should_postgresql_enum_convert():
+    assert_column_conversion(postgresql.ENUM(), graphene.String)
+
+
+def test_should_postgresql_array_convert():
+    assert_column_conversion(postgresql.ARRAY(types.Integer), graphene.List)
+
+
+def test_should_postgresql_json_convert():
+    assert_column_conversion(postgresql.JSON(), JSONString)
+
+
+def test_should_postgresql_jsonb_convert():
+    assert_column_conversion(postgresql.JSONB(), JSONString)
+
+
+def test_should_postgresql_hstore_convert():
+    assert_column_conversion(postgresql.HSTORE(), JSONString)


### PR DESCRIPTION
Issue #172

Added converters for postgresql types : 

* `ARRAY`
* `JSON`
* `JSONB`
* `UUID`
* `ENUM`
* `HSTORE`
