### PR TITLE
[Docs] Make it more obvious that the `node` Field is required for relay

### DIFF
--- a/docs/pages/docs/relay.md
+++ b/docs/pages/docs/relay.md
@@ -54,6 +54,8 @@ class Query(graphene.ObjectType):
     node = relay.NodeField()
 ```
 
+If you encounter an error like `Cannot query field "node" on type "Query"`, you most likely forgot to add the `node` Field.
+
 ## Mutations
 
 Most APIs don't just allow you to read data, they also allow you to write. In GraphQL, this is done using mutations. Just like queries, Relay puts some additional requirements on mutations, but Graphene nicely manages that for you. All you need to do is make your mutation a subclass of `relay.ClientIDMutation`.


### PR DESCRIPTION
For me it was not obvious that you need a node Field in your Query. I hope this makes the documentation a bit better. Also it now gives the error message that occurs if you forget the node Field, so googling for this brings you right to the documentation.

It took me way longer than I'd like to admit to find this ^^