### PR TITLE
Added returns_promise flag to schema.execute

### DIFF
--- a/graphene/core/schema.py
+++ b/graphene/core/schema.py
@@ -118,7 +118,7 @@ class Schema(object):
         return self._types_names
 
     def execute(self, request_string='', root_value=None, variable_values=None,
-                context_value=None, operation_name=None, executor=None):
+                context_value=None, operation_name=None, executor=None, return_promise=False):
         return graphql(
             schema=self.schema,
             request_string=request_string,
@@ -126,7 +126,8 @@ class Schema(object):
             context_value=context_value,
             variable_values=variable_values,
             operation_name=operation_name,
-            executor=executor or self._executor
+            executor=executor or self._executor,
+            return_promise=return_promise
         )
 
     def introspect(self):

--- a/graphene/core/tests/test_schema.py
+++ b/graphene/core/tests/test_schema.py
@@ -1,5 +1,6 @@
 from graphql import graphql
 from py.test import raises
+from promise import is_thenable
 
 from graphene import Interface, List, ObjectType, Schema, String
 from graphene.core.fields import Field
@@ -87,6 +88,19 @@ def test_query_schema_execute():
     result = schema.execute(query, root_value=object())
     assert not result.errors
     assert result.data == expected
+
+def test_schema_returns_promise():
+    object()
+    query = '''
+    {
+      name
+      pet {
+        type
+      }
+    }
+    '''
+    result = schema.execute(query, root_value=object(), return_promise=True)
+    assert is_thenable(result)
 
 
 def test_schema_get_type_map():

--- a/graphene/core/tests/test_schema.py
+++ b/graphene/core/tests/test_schema.py
@@ -89,6 +89,7 @@ def test_query_schema_execute():
     assert not result.errors
     assert result.data == expected
 
+
 def test_schema_returns_promise():
     object()
     query = '''

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ class PyTest(TestCommand):
 
 setup(
     name='graphene',
-    version='0.10.2',
+    version='0.10.3',
 
     description='GraphQL Framework for Python',
     long_description=open('README.rst').read(),


### PR DESCRIPTION
This PR adds an additional flag to the `execute` method of the schema so that the execution returns a promise.