### PR TITLE
Added breaking test to demonstrate wanted subclassing feature.

### DIFF
--- a/graphene/relay/tests/test_mutation.py
+++ b/graphene/relay/tests/test_mutation.py
@@ -27,10 +27,13 @@ class OtherMutation(ClientIDMutation):
     class Input(SharedFields):
         additional_field = String()
 
+    name = String()
+
     @classmethod
     def mutate_and_get_payload(cls, args, context, info):
-        what = args.get('what')
-        return SaySomething(shared=str(what), additional_field='additional')
+        shared = args.get('shared', '')
+        additionalField = args.get('additionalField', '')
+        return SaySomething(name=shared + additionalField)
 
 
 class RootQuery(ObjectType):
@@ -73,6 +76,17 @@ def test_mutation_input():
     assert fields['what'].type == String
     assert isinstance(fields['client_mutation_id'], InputField)
     assert fields['client_mutation_id'].type == String
+
+
+def test_subclassed_mutation():
+    fields = OtherMutation._meta.fields
+    assert list(fields.keys()) == ['name']
+    assert isinstance(fields['name'], Field)
+    field = OtherMutation.Field()
+    assert field.type == OtherMutation
+    assert list(field.args.keys()) == ['input']
+    assert isinstance(field.args['input'], Argument)
+    assert field.args['input'].type == OtherMutation.Input
 
 
 def test_subclassed_mutation_input():

--- a/graphene/relay/tests/test_node.py
+++ b/graphene/relay/tests/test_node.py
@@ -7,6 +7,19 @@ from ..connection import Connection
 from ..node import Node
 
 
+class SharedNodeFields(ObjectType):
+
+    class Meta:
+        interfaces = (Node, )
+
+    shared = String()
+    something_else = String()
+
+    @classmethod
+    def get_node(cls, id, *_):
+        return cls(shared=str(id))
+
+
 class MyNode(ObjectType):
 
     class Meta:
@@ -18,11 +31,18 @@ class MyNode(ObjectType):
         return MyNode(name=str(id))
 
 
+class MyOtherNode(SharedNodeFields):
+    extra_field = String()
+
+    def resolve_extra_field(self, *_):
+        return 'extra field info.'
+
+
 class RootQuery(ObjectType):
     first = String()
     node = Node.Field()
 
-schema = Schema(query=RootQuery, types=[MyNode])
+schema = Schema(query=RootQuery, types=[MyNode, MyOtherNode])
 
 
 def test_node_no_get_node():
@@ -66,6 +86,14 @@ def test_node_query():
     assert executed.data == {'node': {'name': '1'}}
 
 
+def test_subclassed_node_query():
+    executed = schema.execute(
+        '{ node(id:"%s") { ... on MyOtherNode { shared, extraField } } }' % to_global_id("MyOtherNode", 1)
+    )
+    assert not executed.errors
+    assert executed.data == {'node': {'shared': '1', 'extraField': 'extra field info'}}
+
+
 def test_node_query_incorrect_id():
     executed = schema.execute(
         '{ node(id:"%s") { ... on MyNode { name } } }' % "something:2"
@@ -83,6 +111,12 @@ schema {
 type MyNode implements Node {
   id: ID!
   name: String
+}
+
+type MyOtherNode implements Node {
+  shared: String
+  somethingElse: String
+  extraField: String
 }
 
 interface Node {

--- a/graphene/relay/tests/test_node.py
+++ b/graphene/relay/tests/test_node.py
@@ -10,6 +10,9 @@ from ..node import Node
 
 class SharedNodeFields(AbstractType):
 
+    class Meta:
+        interfaces = (Node, )
+
     shared = String()
     something_else = String()
 
@@ -30,9 +33,6 @@ class MyNode(ObjectType):
 
 class MyOtherNode(SharedNodeFields, ObjectType):
     extra_field = String()
-
-    class Meta:
-        interfaces = (Node, )
 
     def resolve_extra_field(self, *_):
         return 'extra field info.'

--- a/graphene/types/tests/test_objecttype.py
+++ b/graphene/types/tests/test_objecttype.py
@@ -81,6 +81,9 @@ def test_generate_objecttype_inherit_abstracttype():
     class MyObjectType(ObjectType, MyAbstractType):
         field2 = MyScalar()
 
+    assert MyObjectType._meta.description is None
+    assert MyObjectType._meta.interfaces == ()
+    assert MyObjectType._meta.name == "MyObjectType"
     assert list(MyObjectType._meta.fields.keys()) == ['field1', 'field2']
     assert list(map(type, MyObjectType._meta.fields.values())) == [Field, Field]
 
@@ -92,6 +95,9 @@ def test_generate_objecttype_inherit_abstracttype_reversed():
     class MyObjectType(MyAbstractType, ObjectType):
         field2 = MyScalar()
 
+    assert MyObjectType._meta.description is None
+    assert MyObjectType._meta.interfaces == ()
+    assert MyObjectType._meta.name == "MyObjectType"
     assert list(MyObjectType._meta.fields.keys()) == ['field1', 'field2']
     assert list(map(type, MyObjectType._meta.fields.values())) == [Field, Field]
 


### PR DESCRIPTION
This is a feature that would really help us clean up our code without affecting the schema. In my opinion putting the `interfaces` on  the meta class is a great step into the right direction already and should simplify this step.

I will also add a test for subclassing/sharing fields between mutation inputs types and normal types (#66). Will also have a bit of a dig into the code-base and see if I can implement that myself.