### PR TITLE
sqla: pass pageinfo_type into connection_from_list_slice

### DIFF
--- a/graphene-sqlalchemy/graphene_sqlalchemy/fields.py
+++ b/graphene-sqlalchemy/graphene_sqlalchemy/fields.py
@@ -2,6 +2,7 @@ from functools import partial
 from sqlalchemy.orm.query import Query
 
 from graphene.relay import ConnectionField
+from graphene.relay.connection import PageInfo
 from graphql_relay.connection.arrayconnection import connection_from_list_slice
 from .utils import get_query
 
@@ -28,6 +29,7 @@ class SQLAlchemyConnectionField(ConnectionField):
             list_length=_len,
             list_slice_length=_len,
             connection_type=connection,
+            pageinfo_type=PageInfo,
             edge_type=connection.Edge,
         )
 


### PR DESCRIPTION
pagination in graphene-sqlalchemy is currently broken as the pageInfo class is not a graphene object type. This change passes the correct PageInfo class into the `connection_from_list_slice` call