### PR TITLE
Support resolver as an argument to the connection

### DIFF
--- a/graphene/relay/connection.py
+++ b/graphene/relay/connection.py
@@ -134,6 +134,6 @@ class IterableConnectionField(Field):
         return connection
 
     def get_resolver(self, parent_resolver):
-        return partial(self.connection_resolver, parent_resolver, self.type)
+        return partial(self.connection_resolver or self.resolver, parent_resolver, self.type)
 
 ConnectionField = IterableConnectionField


### PR DESCRIPTION
Sometime when creating a connection you want to use the resolver argument instead of the default resolver (the `resolve_<field_name>` one):
```
products = IterableConnectionField(ProdictType, resolver=get_products)
```

When we get to `get_resolver` the `parent_resolver` argument will be None.
However, `self.resolver` is set but no one is using it...
