### PR TITLE
next: handle objects being constructed in the typemap multiple times

### DIFF
--- a/graphene/types/typemap.py
+++ b/graphene/types/typemap.py
@@ -119,6 +119,8 @@ class TypeMap(GraphQLTypeMap):
     @classmethod
     def construct_objecttype(cls, map, type):
         from .definitions import GrapheneObjectType
+        if type._meta.name in map:
+            return map
         map[type._meta.name] = GrapheneObjectType(
             graphene_type=type,
             name=type._meta.name,


### PR DESCRIPTION
When using a Union type, it can happen that `construct_objecttype` is called multiple times for the same type. This change bails early if the object is already in the map.