### PR TITLE
Re-add default value for Field.

### DIFF
--- a/graphene/types/field.py
+++ b/graphene/types/field.py
@@ -2,6 +2,8 @@ import inspect
 from collections import Mapping, OrderedDict
 from functools import partial
 
+from promise import Promise
+
 from ..utils.orderedtype import OrderedType
 from .argument import to_arguments
 from .structures import NonNull
@@ -18,7 +20,8 @@ class Field(OrderedType):
 
     def __init__(self, type, args=None, resolver=None, source=None,
                  deprecation_reason=None, name=None, description=None,
-                 required=False, _creation_counter=None, **extra_args):
+                 required=False, _creation_counter=None, default_value=None,
+                 **extra_args):
         super(Field, self).__init__(_creation_counter=_creation_counter)
         assert not args or isinstance(args, Mapping), (
             'Arguments in a field have to be a mapping, received "{}".'
@@ -27,7 +30,7 @@ class Field(OrderedType):
             'A Field cannot have a source and a resolver in at the same time.'
         )
 
-        if required:
+        if required or default_value is not None:
             type = NonNull(type)
 
         self.name = name
@@ -38,6 +41,7 @@ class Field(OrderedType):
         self.resolver = resolver
         self.deprecation_reason = deprecation_reason
         self.description = description
+        self.default_value = default_value
 
     @property
     def type(self):
@@ -46,4 +50,14 @@ class Field(OrderedType):
         return self._type
 
     def get_resolver(self, parent_resolver):
-        return self.resolver or parent_resolver
+        resolver = self.resolver or parent_resolver
+
+        def default_resolve(result):
+            return self.default_value if result is None else result
+
+        def defualt_resolver(self, *args, **kwargs):
+            return Promise.resolve(
+                resolver(*args, **kwargs)
+            ).then(default_resolve)
+
+        return defualt_resolver if self.default_value is not None else resolver

--- a/graphene/types/field.py
+++ b/graphene/types/field.py
@@ -18,7 +18,7 @@ def source_resolver(source, root, args, context, info):
 
 class Field(OrderedType):
 
-    def __init__(self, type, args=None, resolver=None, source=None,
+    def __init__(self, object_type, args=None, resolver=None, source=None,
                  deprecation_reason=None, name=None, description=None,
                  required=False, _creation_counter=None, default_value=None,
                  **extra_args):
@@ -29,12 +29,15 @@ class Field(OrderedType):
         assert not (source and resolver), (
             'A Field cannot have a source and a resolver in at the same time.'
         )
+        assert not callable(default_value), (
+            'The default value can not be a function but received "{}".'
+        ).format(type(default_value))
 
         if required or default_value is not None:
-            type = NonNull(type)
+            object_type = NonNull(object_type)
 
         self.name = name
-        self._type = type
+        self._type = object_type
         self.args = to_arguments(args or OrderedDict(), extra_args)
         if source:
             resolver = partial(source_resolver, source)

--- a/graphene/types/tests/test_field.py
+++ b/graphene/types/tests/test_field.py
@@ -46,7 +46,8 @@ def test_field_default_value_not_callable():
     try:
         Field(MyType, default_value=lambda: True)
     except AssertionError as e:
-        assert str(e) == 'The default value can not be a function but received "<type \'function\'>".'
+        # substring comparison for py 2/3 compatibility
+        assert 'The default value can not be a function but received' in str(e)
 
 
 def test_field_source():

--- a/graphene/types/tests/test_field.py
+++ b/graphene/types/tests/test_field.py
@@ -41,6 +41,14 @@ def test_field_required():
     assert field.type.of_type == MyType
 
 
+def test_field_default_value_not_callable():
+    MyType = object()
+    try:
+        Field(MyType, default_value=lambda: True)
+    except AssertionError as e:
+        assert str(e) == 'The default value can not be a function but received "<type \'function\'>".'
+
+
 def test_field_source():
     MyType = object()
     field = Field(MyType, source='value')

--- a/graphene/types/tests/test_field.py
+++ b/graphene/types/tests/test_field.py
@@ -16,19 +16,22 @@ def test_field_basic():
     resolver = lambda: None
     deprecation_reason = 'Deprecated now'
     description = 'My Field'
+    my_default='something'
     field = Field(
         MyType,
         name='name',
         args=args,
         resolver=resolver,
         description=description,
-        deprecation_reason=deprecation_reason
+        deprecation_reason=deprecation_reason,
+        default_value=my_default,
     )
     assert field.name == 'name'
     assert field.args == args
     assert field.resolver == resolver
     assert field.deprecation_reason == deprecation_reason
     assert field.description == description
+    assert field.default_value == my_default
 
 
 def test_field_required():


### PR DESCRIPTION
This used to exist in `0.x` (with `default`) though. We are using it in a few cases and I do think it is a quite nice sugar.

Also this time it does not allow `callable` since that doesn't really seem to bring any benefits anymore over just providing the `resolver` function.