### PR TITLE
Allow initialising ObjectType with private state.

### DIFF
--- a/graphene/types/objecttype.py
+++ b/graphene/types/objecttype.py
@@ -95,7 +95,7 @@ class ObjectType(six.with_metaclass(ObjectTypeMeta)):
         if kwargs:
             for prop in list(kwargs):
                 try:
-                    if isinstance(getattr(self.__class__, prop), property):
+                    if isinstance(getattr(self.__class__, prop), property) or prop.startswith('_'):
                         setattr(self, prop, kwargs.pop(prop))
                 except AttributeError:
                     pass

--- a/graphene/types/tests/test_objecttype.py
+++ b/graphene/types/tests/test_objecttype.py
@@ -64,6 +64,20 @@ def test_generate_objecttype_with_fields():
     assert 'field' in MyObjectType._meta.fields
 
 
+def test_generate_objecttype_with_private_attributes():
+    class MyObjectType(ObjectType):
+        _private_state = None
+
+    assert '_private_state' not in MyObjectType._meta.fields
+    assert hasattr(MyObjectType, '_private_state')
+
+    m = MyObjectType(_private_state='custom')
+    assert m._private_state == 'custom'
+
+    with pytest.raises(TypeError):
+        MyObjectType(_other_private_state='Wrong')
+
+
 def test_ordered_fields_in_objecttype():
     class MyObjectType(ObjectType):
         b = Field(MyType)


### PR DESCRIPTION
This succeeds https://github.com/graphql-python/graphene/pull/235 against the new `1.0` version.