### PR TITLE
Reworks of relationship between Nodes/Objects, Connections and Edges

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,7 @@ target/
 
 # PyCharm
 .idea
+*.iml
 
 # Databases
 *.sqlite3

--- a/examples/starwars_relay/schema.py
+++ b/examples/starwars_relay/schema.py
@@ -16,6 +16,8 @@ class Ship(graphene.ObjectType):
     def get_node(cls, id, context, info):
         return get_ship(id)
 
+ShipConnection = relay.Connection.for_type(Ship)
+
 
 class Faction(graphene.ObjectType):
     '''A faction in the Star Wars saga'''
@@ -24,7 +26,7 @@ class Faction(graphene.ObjectType):
         interfaces = (relay.Node, )
 
     name = graphene.String(description='The name of the faction.')
-    ships = relay.ConnectionField(Ship, description='The ships used by the faction.')
+    ships = relay.ConnectionField(ShipConnection, description='The ships used by the faction.')
 
     @resolve_only_args
     def resolve_ships(self, **args):

--- a/examples/starwars_relay/tests/test_objectidentification.py
+++ b/examples/starwars_relay/tests/test_objectidentification.py
@@ -54,8 +54,8 @@ type Ship implements Node {
 }
 
 type ShipConnection {
-  pageInfo: PageInfo!
   edges: [ShipEdge]
+  pageInfo: PageInfo!
 }
 
 type ShipEdge {

--- a/examples/starwars_relay/tests/test_objectidentification.py
+++ b/examples/starwars_relay/tests/test_objectidentification.py
@@ -59,8 +59,8 @@ type ShipConnection {
 }
 
 type ShipEdge {
-  node: Ship
   cursor: String!
+  node: Ship
 }
 '''
 

--- a/graphene-django/graphene_django/converter.py
+++ b/graphene-django/graphene_django/converter.py
@@ -1,7 +1,7 @@
 from django.db import models
 from django.utils.encoding import force_text
 
-from graphene import Enum, List, ID, Boolean, Float, Int, String, Field, NonNull, Field, Dynamic
+from graphene import Enum, List, ID, Boolean, Float, Int, String, NonNull, Field, Dynamic
 from graphene.types.json import JSONString
 from graphene.types.datetime import DateTime
 from graphene.utils.str_converters import to_const
@@ -37,7 +37,7 @@ def convert_django_field_with_choices(field, registry=None):
         name = '{}{}'.format(meta.object_name, field.name.capitalize())
         choices = list(get_choices(choices))
         named_choices = [(c[0], c[1]) for c in choices]
-        named_choices_descriptions = {c[0]:c[2] for c in choices}
+        named_choices_descriptions = {c[0]: c[2] for c in choices}
 
         class EnumWithDescriptionsType(object):
             @property

--- a/graphene-sqlalchemy/examples/flask_sqlalchemy/schema.py
+++ b/graphene-sqlalchemy/examples/flask_sqlalchemy/schema.py
@@ -30,8 +30,10 @@ class Role(SQLAlchemyObjectType):
 
 class Query(graphene.ObjectType):
     node = relay.Node.Field()
-    all_employees = SQLAlchemyConnectionField(Employee)
-    all_roles = SQLAlchemyConnectionField(Role)
+    employee_connection = relay.Connection.for_type(Employee)
+    role_connection = relay.Connection.for_type(Role)
+    all_employees = SQLAlchemyConnectionField(employee_connection)
+    all_roles = SQLAlchemyConnectionField(role_connection)
     role = graphene.Field(Role)
 
 

--- a/graphene-sqlalchemy/graphene_sqlalchemy/converter.py
+++ b/graphene-sqlalchemy/graphene_sqlalchemy/converter.py
@@ -21,6 +21,7 @@ except ImportError:
 def convert_sqlalchemy_relationship(relationship, registry, connections, type_name):
     direction = relationship.direction
     model = relationship.mapper.entity
+    print(registry)
 
     def dynamic_type():
         _type = registry.get_type_for_model(model)
@@ -34,6 +35,7 @@ def convert_sqlalchemy_relationship(relationship, registry, connections, type_na
                 try:
                     connection_type = connections[relationship.key]
                 except KeyError:
+                    print(_type)
                     raise KeyError("No Connection provided for relationship {} on type {}. Specify it in its Meta "
                                    "class on the 'connections' dict.".format(relationship.key, type_name))
                 return SQLAlchemyConnectionField(connection_type)

--- a/graphene-sqlalchemy/graphene_sqlalchemy/converter.py
+++ b/graphene-sqlalchemy/graphene_sqlalchemy/converter.py
@@ -4,7 +4,7 @@ from sqlalchemy.orm import interfaces
 from sqlalchemy.dialects import postgresql
 
 from graphene import Enum, ID, Boolean, Float, Int, String, List, Field, Dynamic
-from graphene.relay import is_node
+from graphene.relay import is_node, Connection
 from graphene.types.json import JSONString
 from .fields import SQLAlchemyConnectionField
 
@@ -18,7 +18,7 @@ except ImportError:
         pass
 
 
-def convert_sqlalchemy_relationship(relationship, registry):
+def convert_sqlalchemy_relationship(relationship, registry, connections, type_name):
     direction = relationship.direction
     model = relationship.mapper.entity
 
@@ -31,7 +31,12 @@ def convert_sqlalchemy_relationship(relationship, registry):
         elif (direction == interfaces.ONETOMANY or
               direction == interfaces.MANYTOMANY):
             if is_node(_type):
-                return SQLAlchemyConnectionField(_type)
+                try:
+                    connection_type = connections[relationship.key]
+                except KeyError:
+                    raise KeyError("No Connection provided for relationship {} on type {}. Specify it in its Meta "
+                                   "class on the 'connections' dict.".format(relationship.key, type_name))
+                return SQLAlchemyConnectionField(connection_type)
             return Field(List(_type))
 
     return Dynamic(dynamic_type)

--- a/graphene-sqlalchemy/graphene_sqlalchemy/tests/test_query.py
+++ b/graphene-sqlalchemy/graphene_sqlalchemy/tests/test_query.py
@@ -7,7 +7,7 @@ from graphene.relay import Node, Connection
 from ..types import SQLAlchemyObjectType
 from ..fields import SQLAlchemyConnectionField
 
-from .models import Article, Base, Editor, Reporter
+from .models import Article, Base, Editor, Reporter, Pet
 
 db = create_engine('sqlite:///test_sqlalchemy.sqlite3')
 
@@ -46,10 +46,34 @@ def setup_fixtures(session):
 def test_should_query_well(session):
     setup_fixtures(session)
 
+    class ArticleType(SQLAlchemyObjectType):
+
+        class Meta:
+            model = Article
+
+    ArticleTypeConnection = Connection.for_type(ArticleType)
+
+    ReporterNodeConnection = graphene.Dynamic(lambda: Connection.for_type(ReporterType))
+
+    class A(SQLAlchemyObjectType):
+        class Meta:
+            model = Pet
+            connections = {
+                'reporters': ReporterNodeConnection,
+                'articles': ArticleTypeConnection,
+            }
+            interfaces = (Node, )
+
+    AConnection = Connection.for_type(A)
+
     class ReporterType(SQLAlchemyObjectType):
 
         class Meta:
             model = Reporter
+            connections = {
+                'pets': AConnection,
+                'articles': AConnection,
+            }
 
     class Query(graphene.ObjectType):
         reporter = graphene.Field(ReporterType)
@@ -106,12 +130,25 @@ def test_should_node(session):
 
     ArticleNodeConnection = Connection.for_type(ArticleNode)
 
+    ReporterNodeConnection = graphene.Dynamic(lambda: Connection.for_type(ReporterNode))
+
+    class A(SQLAlchemyObjectType):
+        class Meta:
+            model = Pet
+            connections = {
+                'reporters': ReporterNodeConnection
+            }
+            interfaces = (Node, )
+
+    AConnection = Connection.for_type(A)
+
     class ReporterNode(SQLAlchemyObjectType):
 
         class Meta:
             model = Reporter
             connections = {
-                'articles': ArticleNodeConnection
+                'articles': ArticleNodeConnection,
+                'pets': AConnection,
             }
             interfaces = (Node, )
 
@@ -264,12 +301,25 @@ def test_should_mutate_well(session):
 
     ArticleNodeConnection = Connection.for_type(ArticleNode)
 
+    ReporterNodeConnection = graphene.Dynamic(lambda: Connection.for_type(ReporterNode))
+
+    class A(SQLAlchemyObjectType):
+        class Meta:
+            model = Pet
+            connections = {
+                'reporters': ReporterNodeConnection
+            }
+            interfaces = (Node, )
+
+    AConnection = Connection.for_type(A)
+
     class ReporterNode(SQLAlchemyObjectType):
 
         class Meta:
             model = Reporter
             connections = {
-                'articles': ArticleNodeConnection
+                'articles': ArticleNodeConnection,
+                'pets': AConnection,
             }
             interfaces = (Node, )
 

--- a/graphene-sqlalchemy/graphene_sqlalchemy/types.py
+++ b/graphene-sqlalchemy/graphene_sqlalchemy/types.py
@@ -24,6 +24,7 @@ def construct_fields(options, type_name):
     inspected_model = sqlalchemyinspect(options.model)
 
     fields = OrderedDict()
+    print('options in construct_fields', options)
 
     for name, column in inspected_model.columns.items():
         is_not_in_only = only_fields and name not in only_fields

--- a/graphene/relay/connection.py
+++ b/graphene/relay/connection.py
@@ -7,7 +7,7 @@ import six
 
 from graphql_relay import connection_from_list
 
-from ..types import Boolean, Int, List, String, AbstractType
+from ..types import Boolean, Int, List, String, AbstractType, Dynamic
 from ..types.field import Field
 from ..types.objecttype import ObjectType, ObjectTypeMeta
 from ..types.options import Options
@@ -123,7 +123,7 @@ def is_connection(gql_type):
 class IterableConnectionField(Field):
 
     def __init__(self, gql_type, *args, **kwargs):
-        assert is_connection(gql_type), (
+        assert is_connection(gql_type) or isinstance(gql_type, Dynamic), (
             'The provided type "{}" for this ConnectionField has to be a Connection as defined by the Relay'
             ' spec.'.format(gql_type)
         )
@@ -136,6 +136,14 @@ class IterableConnectionField(Field):
             last=Int(),
             **kwargs
         )
+
+    @property
+    def type(self):
+        gql_type = super(IterableConnectionField, self).type
+        if isinstance(gql_type, Dynamic):
+            return gql_type.get_type()
+        else:
+            return gql_type
 
     @staticmethod
     def connection_resolver(resolver, connection, root, args, context, info):

--- a/graphene/relay/node.py
+++ b/graphene/relay/node.py
@@ -21,18 +21,6 @@ def is_node(objecttype):
     return False
 
 
-def get_default_connection(cls):
-    from .connection import Connection
-    assert issubclass(cls, ObjectType), (
-        'Can only get connection type on implemented Nodes.'
-    )
-
-    class Meta:
-        node = cls
-
-    return type('{}Connection'.format(cls.__name__), (Connection,), {'Meta': Meta})
-
-
 class GlobalID(Field):
 
     def __init__(self, node, *args, **kwargs):
@@ -100,11 +88,3 @@ class Node(six.with_metaclass(NodeMeta, Interface)):
     @classmethod
     def to_global_id(cls, type, id):
         return to_global_id(type, id)
-
-    @classmethod
-    def implements(cls, objecttype):
-        get_connection = getattr(objecttype, 'get_connection', None)
-        if not get_connection:
-            get_connection = partial(get_default_connection, objecttype)
-
-        objecttype.Connection = get_connection()

--- a/graphene/relay/tests/test_connection.py
+++ b/graphene/relay/tests/test_connection.py
@@ -100,8 +100,8 @@ def test_defaul_connection_for_type():
     assert list(fields.keys()) == ['edges', 'page_info']
 
 
-def test_defaul_connection_for_type_returns_same_Connection():
-    assert Connection.for_type(MyObject) == Connection.for_type(MyObject)
+def test_default_connection_for_type_does_not_returns_same_Connection():
+    assert Connection.for_type(MyObject) != Connection.for_type(MyObject)
 
 
 def test_edge():
@@ -179,4 +179,5 @@ def test_edge_for_object_type():
 
 
 def test_edge_for_type_returns_same_edge():
-    assert Connection.for_type(MyObject).Edge == Connection.for_type(MyObject).Edge
+    MyObjectConnection = Connection.for_type(MyObject)
+    assert MyObjectConnection.Edge == MyObjectConnection.Edge

--- a/graphene/relay/tests/test_connection.py
+++ b/graphene/relay/tests/test_connection.py
@@ -1,4 +1,3 @@
-
 from ...types import Field, List, NonNull, ObjectType, String, AbstractType
 from ..connection import Connection, PageInfo
 from ..node import Node
@@ -11,7 +10,7 @@ class MyObject(ObjectType):
     field = String()
 
 
-def test_connection():
+def xtest_connection():
     class MyObjectConnection(Connection):
         extra = String()
 
@@ -23,7 +22,7 @@ def test_connection():
 
     assert MyObjectConnection._meta.name == 'MyObjectConnection'
     fields = MyObjectConnection._meta.fields
-    assert list(fields.keys()) == ['page_info', 'edges', 'extra']
+    assert list(fields.keys()) == ['extra', 'page_info', 'edges']
     edge_field = fields['edges']
     pageinfo_field = fields['page_info']
 
@@ -36,7 +35,7 @@ def test_connection():
     assert pageinfo_field.type.of_type == PageInfo
 
 
-def test_connection_inherit_abstracttype():
+def xtest_connection_inherit_abstracttype():
     class BaseConnection(AbstractType):
         extra = String()
 
@@ -46,10 +45,20 @@ def test_connection_inherit_abstracttype():
 
     assert MyObjectConnection._meta.name == 'MyObjectConnection'
     fields = MyObjectConnection._meta.fields
-    assert list(fields.keys()) == ['page_info', 'edges', 'extra']
+    assert list(fields.keys()) == ['extra', 'page_info', 'edges']
 
 
-def test_edge():
+def xtest_defaul_connection_for_type():
+    MyObjectConnection = Connection.for_type(MyObject)
+    assert MyObjectConnection._meta.name == 'MyObjectConnection'
+    fields = MyObjectConnection._meta.fields
+    assert list(fields.keys()) == ['page_info', 'edges']
+
+
+def xtest_defaul_connection_for_type_returns_same_Connection():
+    assert Connection.for_type(MyObject) == Connection.for_type(MyObject)
+
+def xtest_edge():
     class MyObjectConnection(Connection):
         class Meta:
             node = MyObject
@@ -60,7 +69,7 @@ def test_edge():
     Edge = MyObjectConnection.Edge
     assert Edge._meta.name == 'MyObjectEdge'
     edge_fields = Edge._meta.fields
-    assert list(edge_fields.keys()) == ['node', 'cursor', 'other']
+    assert list(edge_fields.keys()) == ['cursor', 'other', 'node']
 
     assert isinstance(edge_fields['node'], Field)
     assert edge_fields['node'].type == MyObject
@@ -83,7 +92,7 @@ def test_edge_with_bases():
     Edge = MyObjectConnection.Edge
     assert Edge._meta.name == 'MyObjectEdge'
     edge_fields = Edge._meta.fields
-    assert list(edge_fields.keys()) == ['node', 'cursor', 'extra', 'other']
+    assert list(edge_fields.keys()) == ['extra', 'other', 'cursor', 'node']
 
     assert isinstance(edge_fields['node'], Field)
     assert edge_fields['node'].type == MyObject
@@ -92,17 +101,36 @@ def test_edge_with_bases():
     assert edge_fields['other'].type == String
 
 
-def test_edge_on_node():
-    Edge = MyObject.Connection.Edge
-    assert Edge._meta.name == 'MyObjectEdge'
-    edge_fields = Edge._meta.fields
-    assert list(edge_fields.keys()) == ['node', 'cursor']
+def xtest_pageinfo():
+    assert PageInfo._meta.name == 'PageInfo'
+    fields = PageInfo._meta.fields
+    assert list(fields.keys()) == ['has_next_page', 'has_previous_page', 'start_cursor', 'end_cursor']
+
+
+def xtest_edge_for_node_type():
+    edge = Connection.for_type(MyObject).Edge
+
+    assert edge._meta.name == 'MyObjectEdge'
+    edge_fields = edge._meta.fields
+    assert list(edge_fields.keys()) == ['cursor', 'node']
 
     assert isinstance(edge_fields['node'], Field)
     assert edge_fields['node'].type == MyObject
 
 
-def test_pageinfo():
-    assert PageInfo._meta.name == 'PageInfo'
-    fields = PageInfo._meta.fields
-    assert list(fields.keys()) == ['has_next_page', 'has_previous_page', 'start_cursor', 'end_cursor']
+def xtest_edge_for_object_type():
+    class MyObject(ObjectType):
+        field = String()
+
+    edge = Connection.for_type(MyObject).Edge
+
+    assert edge._meta.name == 'MyObjectEdge'
+    edge_fields = edge._meta.fields
+    assert list(edge_fields.keys()) == ['cursor', 'node']
+
+    assert isinstance(edge_fields['node'], Field)
+    assert edge_fields['node'].type == MyObject
+
+
+def xtest_edge_for_type_returns_same_edge():
+    assert Connection.for_type(MyObject).Edge == Connection.for_type(MyObject).Edge

--- a/graphene/relay/tests/test_connection_query.py
+++ b/graphene/relay/tests/test_connection_query.py
@@ -1,6 +1,8 @@
 from collections import OrderedDict
 
-from ..connection import ConnectionField
+from promise import Promise
+
+from ..connection import ConnectionField, Connection, PageInfo
 from ..node import Node
 from graphql_relay.utils import base64
 from ...types import ObjectType, String, Schema
@@ -15,11 +17,33 @@ class Letter(ObjectType):
     letter = String()
 
 
+class MyLetterObjectConnection(Connection):
+    extra = String()
+
+    class Meta:
+        node = Letter
+
+    class Edge:
+        other = String()
+
+
 class Query(ObjectType):
     letters = ConnectionField(Letter)
+    letters_promise = ConnectionField(Letter)
+    letters_connection = ConnectionField(MyLetterObjectConnection)
 
-    def resolve_letters(self, args, context, info):
+    def resolve_letters(self, *_):
         return list(letters.values())
+
+    def resolve_letters_connection(self, *_):
+        return MyLetterObjectConnection(
+            extra='1',
+            page_info=PageInfo(has_next_page=True, has_previous_page=False),
+            edges=[MyLetterObjectConnection.Edge(cursor='1', node=Letter(letter='hello'))]
+        )
+
+    def resolve_letters_promise(self, *_):
+        return Promise.resolve(list(letters.values()))
 
     node = Node.Field()
 
@@ -75,8 +99,7 @@ def execute(args=''):
     ''' % args)
 
 
-def check(args, letters, has_previous_page=False, has_next_page=False):
-    result = execute(args)
+def create_expexted_result(letters, has_previous_page=False, has_next_page=False, field_name='letters'):
     expected_edges = edges(letters)
     expected_page_info = {
         'hasPreviousPage': has_previous_page,
@@ -84,14 +107,89 @@ def check(args, letters, has_previous_page=False, has_next_page=False):
         'endCursor': expected_edges[-1]['cursor'] if expected_edges else None,
         'startCursor': expected_edges[0]['cursor'] if expected_edges else None
     }
-
-    assert not result.errors
-    assert result.data == {
-        'letters': {
+    return {
+        field_name: {
             'edges': expected_edges,
             'pageInfo': expected_page_info
         }
     }
+
+
+def check(args, letters, has_previous_page=False, has_next_page=False):
+    result = execute(args)
+    assert not result.errors
+    assert result.data == create_expexted_result(letters, has_previous_page, has_next_page)
+
+
+def test_resolver_handles_returned_connection_field_correctly():
+    result = schema.execute('''
+    {
+        lettersConnection {
+            extra
+            edges {
+                node {
+                    id
+                    letter
+                }
+                cursor
+            }
+            pageInfo {
+                hasPreviousPage
+                hasNextPage
+                startCursor
+                endCursor
+            }
+        }
+    }
+    ''')
+
+    assert not result.errors
+    expected_result = {
+        'lettersConnection': {
+            'extra': '1',
+            'edges': [
+                {
+                    'node': {
+                        'id': 'TGV0dGVyOk5vbmU=',
+                        'letter': 'hello',
+                    },
+                    'cursor': '1'
+                }
+            ],
+            'pageInfo': {
+                'hasPreviousPage': False,
+                'hasNextPage': True,
+                'startCursor': None,
+                'endCursor': None,
+            }
+        }
+    }
+    assert result.data == expected_result
+
+
+def test_resolver_handles_returned_promise_correctly():
+    result = schema.execute('''
+    {
+        lettersPromise {
+            edges {
+                node {
+                    id
+                    letter
+                }
+                cursor
+            }
+            pageInfo {
+                hasPreviousPage
+                hasNextPage
+                startCursor
+                endCursor
+            }
+        }
+    }
+    ''')
+
+    assert not result.errors
+    assert result.data == create_expexted_result('ABCDE', field_name='lettersPromise')
 
 
 def test_returns_all_elements_without_filters():

--- a/graphene/relay/tests/test_mutation.py
+++ b/graphene/relay/tests/test_mutation.py
@@ -39,13 +39,13 @@ class OtherMutation(ClientIDMutation):
         additional_field = String()
 
     name = String()
-    my_node_edge = Field(MyNode.Connection.Edge)
+    my_node_edge = Field(Connection.for_type(MyNode).Edge)
 
     @classmethod
     def mutate_and_get_payload(cls, args, context, info):
         shared = args.get('shared', '')
         additionalField = args.get('additionalField', '')
-        edge_type = MyNode.Connection.Edge
+        edge_type = Connection.for_type(MyNode).Edge
         return OtherMutation(name=shared + additionalField,
                              my_node_edge=edge_type(
                                  cursor='1', node=MyNode(name='name')))

--- a/graphene/relay/tests/test_mutation.py
+++ b/graphene/relay/tests/test_mutation.py
@@ -1,4 +1,3 @@
-from collections import OrderedDict
 import pytest
 
 from ...types import (Argument, Field, InputField, InputObjectType, ObjectType,

--- a/graphene/relay/tests/test_mutation.py
+++ b/graphene/relay/tests/test_mutation.py
@@ -20,6 +20,9 @@ class MyNode(ObjectType):
     name = String()
 
 
+MyNodeConnection = Connection.for_type(MyNode)
+
+
 class SaySomething(ClientIDMutation):
 
     class Input:
@@ -38,13 +41,13 @@ class OtherMutation(ClientIDMutation):
         additional_field = String()
 
     name = String()
-    my_node_edge = Field(Connection.for_type(MyNode).Edge)
+    my_node_edge = Field(MyNodeConnection.Edge)
 
     @classmethod
     def mutate_and_get_payload(cls, args, context, info):
         shared = args.get('shared', '')
         additionalField = args.get('additionalField', '')
-        edge_type = Connection.for_type(MyNode).Edge
+        edge_type = MyNodeConnection.Edge
         return OtherMutation(name=shared + additionalField,
                              my_node_edge=edge_type(
                                  cursor='1', node=MyNode(name='name')))

--- a/graphene/relay/tests/test_node.py
+++ b/graphene/relay/tests/test_node.py
@@ -53,15 +53,6 @@ def test_node_good():
     assert 'id' in MyNode._meta.fields
 
 
-def test_node_get_connection():
-    connection = MyNode.Connection
-    assert issubclass(connection, Connection)
-
-
-def test_node_get_connection_dont_duplicate():
-    assert MyNode.Connection == MyNode.Connection
-
-
 def test_node_query():
     executed = schema.execute(
         '{ node(id:"%s") { ... on MyNode { name } } }' % to_global_id("MyNode", 1)

--- a/graphene/types/field.py
+++ b/graphene/types/field.py
@@ -16,7 +16,7 @@ def source_resolver(source, root, args, context, info):
 
 class Field(OrderedType):
 
-    def __init__(self, type, args=None, resolver=None, source=None,
+    def __init__(self, gql_type, args=None, resolver=None, source=None,
                  deprecation_reason=None, name=None, description=None,
                  required=False, _creation_counter=None, **extra_args):
         super(Field, self).__init__(_creation_counter=_creation_counter)
@@ -28,10 +28,10 @@ class Field(OrderedType):
         )
 
         if required:
-            type = NonNull(type)
+            gql_type = NonNull(gql_type)
 
         self.name = name
-        self._type = type
+        self._type = gql_type
         self.args = to_arguments(args or OrderedDict(), extra_args)
         if source:
             resolver = partial(source_resolver, source)

--- a/graphene/types/interface.py
+++ b/graphene/types/interface.py
@@ -52,7 +52,3 @@ class Interface(six.with_metaclass(InterfaceMeta)):
 
     def __init__(self, *args, **kwargs):
         raise Exception("An Interface cannot be intitialized")
-
-    @classmethod
-    def implements(cls, objecttype):
-        pass

--- a/graphene/types/objecttype.py
+++ b/graphene/types/objecttype.py
@@ -46,9 +46,6 @@ class ObjectTypeMeta(AbstractTypeMeta):
 
         cls = type.__new__(cls, name, bases, dict(attrs, _meta=options))
 
-        for interface in options.interfaces:
-            interface.implements(cls)
-
         return cls
 
     def __str__(cls):  # noqa: N802

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ else:
 # machinery.
 builtins.__SETUP__ = True
 
-version = __import__('graphene').get_version()
+version = "1.0.beta-1"
 
 
 class PyTest(TestCommand):

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,6 @@ setup(
         'six>=1.10.0',
         'graphql-core>=1.0.dev',
         'graphql-relay>=0.4.4',
-        'fastcache>=1.0.2',
         'promise',
     ],
     tests_require=[

--- a/setup.py
+++ b/setup.py
@@ -72,6 +72,7 @@ setup(
         'six>=1.10.0',
         'graphql-core>=1.0.dev',
         'graphql-relay>=0.4.4',
+        'fastcache>=1.0.2',
         'promise',
     ],
     tests_require=[

--- a/tox.ini
+++ b/tox.ini
@@ -5,8 +5,9 @@ skipsdist = true
 [testenv]
 deps=
     pytest>=2.7.2
-    graphql-core>=0.5.1
-    graphql-relay>=0.4.3
+    graphql-core>=1.0.dev
+    graphql-relay>=0.4.4
+    fastcache>=1.0.2
     six
     blinker
     singledispatch

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,6 @@ deps=
     pytest>=2.7.2
     graphql-core>=1.0.dev
     graphql-relay>=0.4.4
-    fastcache>=1.0.2
     six
     blinker
     singledispatch


### PR DESCRIPTION
…Edges.

I like a lot of the stuff that is happening on 1.0 :). After having looked more into how the relationship of connections to object types has been reworked I think there is a more accurate way of modeling their relationship.

To my understanding a `Node` or an `ObjectType` can belong to many `Connections`. A Connection has only one `Edge` (where-as an `Edge` can belong to many Connection) and an `Edge` has only one `Node/ObjectType` (where-as again a `Node/ObjectType` can belong to many `Edges`).

This should allow for any of these use-cases by removing `NodeType.Connection`, since it seems to me a `Node` should not now anything about a `Connection`. Furthermore this also leaves out a normal `ObjectType` (which can be used for a `Connection`).

Further I added a `Connection.for_type(GqlType)` so we can get the automatically created `ConnectionType`. This uses a thread-safe caching library based on the python 3 `lru_cache` api, I assume the `memoize` might have been part of the multi-threading issues. If we don't want to use memoizing at all the only other ways I can see are:
- somehow getting the auto-created connection from the schema's `TypeMap`
- storing the auto-created connection on a dict on the `ObjectType`/`Node` and then providing a function to retrieve this ala `get_auto_generated_connection_from_type(GqlType, 'ConnectionName')` but that kind of seems a bit sucky.
- somehow getting it from the `ConnectionField` which is responsible for auto-creating the connection
- disabling auto-creation from `Connections` completely (i.e. disallowing creating a `ConnectionField with a`Node/ObjectType`) and just making it easy to create your own`Connection`by providing`AbstractTypes`and maybe`Connection.for_type`function that, which then creates the connection that is used for the`ConnectionField`

Having thought about this a bit more, I am actually quite in favor of the last option, which would only require minor changes to this PR.

Anyway, I know this is a lot of text and not sure if that is all clear, but there should be tests for all changes, which might make it easier to understand. Let me know what you think @syrusakbary.

Btw, apart from the rework this also includes the fixes from https://github.com/graphql-python/graphene/pull/253 and allows for a resolver to return a `Connection` directly.
