### PR TITLE
fix the hello world example in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Here is one example for get you started:
 class Query(graphene.ObjectType):
     hello = graphene.String(description='A typical hello world')
 
-    def resolve_hello(self, args, context, info):
+    def resolve_hello(self, args, info):
         return 'World'
 
 schema = graphene.Schema(query=Query)

--- a/README.rst
+++ b/README.rst
@@ -58,7 +58,7 @@ Here is one example for get you started:
     class Query(graphene.ObjectType):
         hello = graphene.String(description='A typical hello world')
 
-        def resolve_hello(self, args, context, info):
+        def resolve_hello(self, args, info):
             return 'World'
 
     schema = graphene.Schema(query=Query)


### PR DESCRIPTION
After initially checking the project out and trying to use it I ran into an error when using the example schema from the README as is. After looking through the source code and also comparing it to the version I saw in the website's getting started docs (http://graphene-python.org/docs/quickstart/), seems like it's a simple fix..

As an aside, perhaps it would be good to get rid of one of the README's so easier to maintain going forward? seems like there's both .md and a .rst versions currently, I updated both for good measure..
