### PR TITLE
Make scalar get_type an instance method.

### DIFF
--- a/graphene/relay/tests/test_connection.py
+++ b/graphene/relay/tests/test_connection.py
@@ -68,7 +68,7 @@ def test_edge():
     assert edge_fields['node'].type == MyObject
 
     assert isinstance(edge_fields['other'], Field)
-    assert edge_fields['other'].type == String
+    assert edge_fields['other'].type.__class__ == String
 
 
 def test_edge_with_bases():
@@ -92,7 +92,7 @@ def test_edge_with_bases():
     assert edge_fields['node'].type == MyObject
 
     assert isinstance(edge_fields['other'], Field)
-    assert edge_fields['other'].type == String
+    assert edge_fields['other'].type.__class__ == String
 
 
 def test_edge_on_node():

--- a/graphene/relay/tests/test_mutation.py
+++ b/graphene/relay/tests/test_mutation.py
@@ -81,7 +81,7 @@ def test_mutation():
     assert field.args['input'].type.of_type == SaySomething.Input
     assert isinstance(fields['client_mutation_id'], Field)
     assert fields['client_mutation_id'].name == 'clientMutationId'
-    assert fields['client_mutation_id'].type == String
+    assert fields['client_mutation_id'].type.__class__ == String
 
 
 def test_mutation_input():
@@ -90,9 +90,9 @@ def test_mutation_input():
     fields = Input._meta.fields
     assert list(fields.keys()) == ['what', 'client_mutation_id']
     assert isinstance(fields['what'], InputField)
-    assert fields['what'].type == String
+    assert fields['what'].type.__class__ == String
     assert isinstance(fields['client_mutation_id'], InputField)
-    assert fields['client_mutation_id'].type == String
+    assert fields['client_mutation_id'].type.__class__ == String
 
 
 def test_subclassed_mutation():
@@ -113,11 +113,11 @@ def test_subclassed_mutation_input():
     fields = Input._meta.fields
     assert list(fields.keys()) == ['shared', 'additional_field', 'client_mutation_id']
     assert isinstance(fields['shared'], InputField)
-    assert fields['shared'].type == String
+    assert fields['shared'].type.__class__ == String
     assert isinstance(fields['additional_field'], InputField)
-    assert fields['additional_field'].type == String
+    assert fields['additional_field'].type.__class__ == String
     assert isinstance(fields['client_mutation_id'], InputField)
-    assert fields['client_mutation_id'].type == String
+    assert fields['client_mutation_id'].type.__class__ == String
 
 
 # def test_node_query():

--- a/graphene/types/scalars.py
+++ b/graphene/types/scalars.py
@@ -41,9 +41,8 @@ class Scalar(six.with_metaclass(ScalarTypeMeta, UnmountedType)):
     parse_value = None
     parse_literal = None
 
-    @classmethod
-    def get_type(cls):
-        return cls
+    def get_type(self):
+        return self
 
 # As per the GraphQL Spec, Integers are only treated as valid when a valid
 # 32-bit signed integer, providing the broadest support across platforms.

--- a/graphene/types/scalars.py
+++ b/graphene/types/scalars.py
@@ -37,10 +37,16 @@ class Scalar(six.with_metaclass(ScalarTypeMeta, UnmountedType)):
     used to parse input from ast or variables and to ensure validity.
     '''
 
+    def  __init__(self):
+        def get_type(self):
+            return self
+        self.get_type = types.MethodType(get_type, self)
+
     serialize = None
     parse_value = None
     parse_literal = None
 
+    @classmethod
     def get_type(self):
         return self
 

--- a/graphene/types/scalars.py
+++ b/graphene/types/scalars.py
@@ -50,8 +50,8 @@ class Scalar(six.with_metaclass(ScalarTypeMeta, UnmountedType)):
     parse_literal = None
 
     @classmethod
-    def get_type(self):
-        return self
+    def get_type(cls):
+        return cls
 
 # As per the GraphQL Spec, Integers are only treated as valid when a valid
 # 32-bit signed integer, providing the broadest support across platforms.

--- a/graphene/types/scalars.py
+++ b/graphene/types/scalars.py
@@ -1,4 +1,5 @@
 import six
+import types
 
 from graphql.language.ast import (BooleanValue, FloatValue, IntValue,
                                   StringValue)
@@ -37,7 +38,7 @@ class Scalar(six.with_metaclass(ScalarTypeMeta, UnmountedType)):
     used to parse input from ast or variables and to ensure validity.
     '''
 
-    def  __init__(self):
+    def __init__(self):
         def get_type(self):
             return self
         self.get_type = types.MethodType(get_type, self)

--- a/graphene/types/scalars.py
+++ b/graphene/types/scalars.py
@@ -38,7 +38,9 @@ class Scalar(six.with_metaclass(ScalarTypeMeta, UnmountedType)):
     used to parse input from ast or variables and to ensure validity.
     '''
 
-    def __init__(self):
+    def __init__(self, *args, **kwargs):
+        super(Scalar, self).__init__(*args, **kwargs)
+
         def get_type(self):
             return self
         self.get_type = types.MethodType(get_type, self)

--- a/graphene/types/tests/test_definition.py
+++ b/graphene/types/tests/test_definition.py
@@ -83,7 +83,7 @@ def test_defines_a_query_only_schema():
     assert issubclass(article_field_type, ObjectType)
 
     title_field = article_field_type._meta.fields['title']
-    assert title_field.type == String
+    assert title_field.type.__class__ == String
 
     author_field = article_field_type._meta.fields['author']
     author_field_type = author_field.type

--- a/graphene/types/typemap.py
+++ b/graphene/types/typemap.py
@@ -24,7 +24,7 @@ from .utils import get_field_as
 
 
 def is_graphene_type(_type):
-    if isinstance(_type, (List, NonNull)):
+    if isinstance(_type, (List, NonNull, Scalar)):
         return True
     if inspect.isclass(_type) and issubclass(_type, (ObjectType, InputObjectType, Scalar, Interface, Union, Enum)):
         return True
@@ -68,6 +68,8 @@ class TypeMap(GraphQLTypeMap):
             if is_graphene_type(_type):
                 assert _type.graphene_type == type
             return map
+        if isinstance(type, Scalar):
+            return self.construct_scalar(map, type.__class__)
         if issubclass(type, ObjectType):
             return self.construct_objecttype(map, type)
         if issubclass(type, InputObjectType):

--- a/graphene/types/unmountedtype.py
+++ b/graphene/types/unmountedtype.py
@@ -63,7 +63,8 @@ class UnmountedType(OrderedType):
         return (
             self is other or (
                 isinstance(other, UnmountedType) and
-                self.get_type() == other.get_type() and
+                self.get_type()._meta == other.get_type()._meta and
+                # self.get_type()._meta.name == other.get_type()._meta.name and
                 self.args == other.args and
                 self.kwargs == other.kwargs
             )


### PR DESCRIPTION
Given the current way of how Scalars are mostly being created in the schema, e.g. `graphene.Boolean(description='Some boolean')` and then how they get 'magically' turned into a `Field` using `self.get_type()` it makes sense to make this an Instance method rather than a classmethod. This allows e.g. to set attributes on the instance that will always be accessible, as they are being returned by `get_type`.

This replaces https://github.com/graphql-python/graphene/pull/325

Further, if you are worried about backwards-compatibility we could also keep this a class method and then simply override that classmethod with an instancemethod on instantiation. Being a 100% backwards-compatible and allowing for the use-case described,

``` py
import types
...
class Scalar(six.with_metaclass(ScalarTypeMeta, UnmountedType)):
    '''
    Scalar Type Definition
    The leaf values of any request and input values to arguments are
    Scalars (or Enums) and are defined with a name and a series of functions
    used to parse input from ast or variables and to ensure validity.
    '''

     def  __init__(self):
        def get_type(self):
            return self
        self.get_type = types.MethodType(get_type, self)

    serialize = None
    parse_value = None
    parse_literal = None

    @classmethod
    def get_type(cls):
        return cls
```
