### PR TITLE
Connection Edges should be NonNull

### DIFF
--- a/examples/starwars_relay/tests/test_objectidentification.py
+++ b/examples/starwars_relay/tests/test_objectidentification.py
@@ -56,7 +56,7 @@ type Ship implements Node {
 
 type ShipConnection {
   pageInfo: PageInfo!
-  edges: [ShipEdge]
+  edges: [ShipEdge]!
 }
 
 type ShipEdge {

--- a/graphene/relay/connection.py
+++ b/graphene/relay/connection.py
@@ -82,7 +82,7 @@ class ConnectionMeta(ObjectTypeMeta):
 
         class ConnectionBase(AbstractType):
             page_info = Field(PageInfo, name='pageInfo', required=True)
-            edges = List(edge)
+            edges = NonNull(List(edge))
 
         bases = (ConnectionBase, ) + bases
         attrs = dict(attrs, _meta=options, Edge=edge)

--- a/graphene/relay/tests/test_connection.py
+++ b/graphene/relay/tests/test_connection.py
@@ -28,8 +28,9 @@ def test_connection():
     pageinfo_field = fields['page_info']
 
     assert isinstance(edge_field, Field)
-    assert isinstance(edge_field.type, List)
-    assert edge_field.type.of_type == MyObjectConnection.Edge
+    assert isinstance(edge_field.type, NonNull)
+    assert isinstance(edge_field.type.of_type, List)
+    assert edge_field.type.of_type.of_type == MyObjectConnection.Edge
 
     assert isinstance(pageinfo_field, Field)
     assert isinstance(pageinfo_field.type, NonNull)


### PR DESCRIPTION
Ass defined in the reference implementation on https://github.com/graphql/graphql-relay-js/blob/5927f0becf43740a1f1026c6e960811c4359d342/src/connection/connectiontypes.js

Solves issue #341 