### PR TITLE
New Connection API

### DIFF
--- a/examples/starwars_relay/schema.py
+++ b/examples/starwars_relay/schema.py
@@ -17,6 +17,11 @@ class Ship(graphene.ObjectType):
         return get_ship(id)
 
 
+class ShipConnection(graphene.Connection):
+    class Meta:
+        node = Ship
+
+
 class Faction(graphene.ObjectType):
     '''A faction in the Star Wars saga'''
 
@@ -24,7 +29,7 @@ class Faction(graphene.ObjectType):
         interfaces = (relay.Node, )
 
     name = graphene.String(description='The name of the faction.')
-    ships = relay.ConnectionField(Ship, description='The ships used by the faction.')
+    ships = ShipConnection.Field(description='The ships used by the faction.')
 
     @resolve_only_args
     def resolve_ships(self, **args):

--- a/graphene/relay/connection.py
+++ b/graphene/relay/connection.py
@@ -96,6 +96,10 @@ class Connection(six.with_metaclass(ConnectionMeta, ObjectType)):
         return ConnectionField(cls, *args, **kwargs)
 
     @classmethod
+    def is_type_of(cls, root, context, info):
+        return isinstance(root, cls)
+
+    @classmethod
     def connection_resolver(cls, resolved, args, context, info):
         assert isinstance(resolved, Iterable), (
             'Resolved value from the connection field have to be iterable or instance of {}. '
@@ -132,7 +136,7 @@ class ConnectionField(Field):
     def connection_resolver(cls, resolver, connection_type, root, args, context, info):
         resolved = resolver(root, args, context, info)
 
-        if isinstance(resolved, connection_type):
+        if connection_type.is_type_of(resolved, context, info):
             return resolved
 
         on_resolve = partial(connection_type.connection_resolver, args=args, context=context, info=info)

--- a/graphene/relay/connection.py
+++ b/graphene/relay/connection.py
@@ -5,7 +5,7 @@ from functools import partial
 import six
 
 from graphql_relay import connection_from_list
-from promise import Promise
+from promise import Promise, is_thenable, promisify
 
 from ..types import (AbstractType, Boolean, Enum, Int, Interface, List, NonNull, Scalar, String,
                      Union)
@@ -140,8 +140,8 @@ class ConnectionField(Field):
             return resolved
 
         on_resolve = partial(connection_type.connection_resolver, args=args, context=context, info=info)
-        if isinstance(resolved, Promise):
-            return resolved.then(on_resolve)
+        if is_thenable(resolved):
+            return promisify(resolved).then(on_resolve)
 
         return on_resolve(resolved)
 

--- a/graphene/relay/connection.py
+++ b/graphene/relay/connection.py
@@ -119,19 +119,14 @@ class ConnectionField(Field):
         kwargs.setdefault('after', String())
         kwargs.setdefault('first', Int())
         kwargs.setdefault('last', Int())
+        assert issubclass(type, Connection), (
+            '{} type have to be a subclass of Connection. Received "{}".'
+        ).format(str(self), type)
         super(ConnectionField, self).__init__(
             type,
             *args,
             **kwargs
         )
-
-    @property
-    def type(self):
-        type = super(ConnectionField, self).type
-        assert issubclass(type, Connection), (
-            '{} type have to be a subclass of Connection. Received "{}".'
-        ).format(str(self), type)
-        return type
 
     @classmethod
     def connection_resolver(cls, resolver, connection_type, root, args, context, info):

--- a/graphene/relay/node.py
+++ b/graphene/relay/node.py
@@ -21,18 +21,6 @@ def is_node(objecttype):
     return False
 
 
-def get_default_connection(cls):
-    from .connection import Connection
-    assert issubclass(cls, ObjectType), (
-        'Can only get connection type on implemented Nodes.'
-    )
-
-    class Meta:
-        node = cls
-
-    return type('{}Connection'.format(cls.__name__), (Connection,), {'Meta': Meta})
-
-
 class GlobalID(Field):
 
     def __init__(self, node, *args, **kwargs):
@@ -101,11 +89,3 @@ class Node(six.with_metaclass(NodeMeta, Interface)):
     @classmethod
     def to_global_id(cls, type, id):
         return to_global_id(type, id)
-
-    @classmethod
-    def implements(cls, objecttype):
-        get_connection = getattr(objecttype, 'get_connection', None)
-        if not get_connection:
-            get_connection = partial(get_default_connection, objecttype)
-
-        objecttype.Connection = get_connection()

--- a/graphene/relay/tests/test_connection.py
+++ b/graphene/relay/tests/test_connection.py
@@ -97,7 +97,11 @@ def test_edge_with_bases():
 
 
 def test_edge_on_node():
-    Edge = MyObject.Connection.Edge
+    class MyObjectConnection(Connection):
+        class Meta:
+            node = MyObject
+
+    Edge = MyObjectConnection.Edge
     assert Edge._meta.name == 'MyObjectEdge'
     edge_fields = Edge._meta.fields
     assert list(edge_fields.keys()) == ['node', 'cursor']

--- a/graphene/relay/tests/test_connection_query.py
+++ b/graphene/relay/tests/test_connection_query.py
@@ -4,7 +4,7 @@ from graphql_relay.utils import base64
 from promise import Promise
 
 from ...types import ObjectType, Schema, String
-from ..connection import ConnectionField, PageInfo
+from ..connection import ConnectionField, Connection, PageInfo
 from ..node import Node
 
 letter_chars = ['A', 'B', 'C', 'D', 'E']
@@ -18,10 +18,15 @@ class Letter(ObjectType):
     letter = String()
 
 
+class LetterConnection(Connection):
+    class Meta:
+        node = Letter
+
+
 class Query(ObjectType):
-    letters = ConnectionField(Letter)
-    connection_letters = ConnectionField(Letter)
-    promise_letters = ConnectionField(Letter)
+    letters = LetterConnection.Field()
+    connection_letters = LetterConnection.Field()
+    promise_letters = LetterConnection.Field()
 
     node = Node.Field()
 
@@ -32,13 +37,13 @@ class Query(ObjectType):
         return Promise.resolve(list(letters.values()))
 
     def resolve_connection_letters(self, args, context, info):
-        return Letter.Connection(
+        return LetterConnection(
             page_info=PageInfo(
                 has_next_page=True,
                 has_previous_page=False
             ),
             edges=[
-                Letter.Connection.Edge(
+                LetterConnection.Edge(
                     node=Letter(id=0, letter='A'),
                     cursor='a-cursor'
                 ),

--- a/graphene/relay/tests/test_mutation.py
+++ b/graphene/relay/tests/test_mutation.py
@@ -3,6 +3,7 @@ import pytest
 from ...types import (AbstractType, Argument, Field, InputField,
                       InputObjectType, NonNull, ObjectType, Schema)
 from ...types.scalars import String
+from ..connection import Connection
 from ..mutation import ClientIDMutation
 from ..node import Node
 
@@ -17,6 +18,11 @@ class MyNode(ObjectType):
         interfaces = (Node, )
 
     name = String()
+
+
+class MyNodeConnection(Connection):
+    class Meta:
+        node = MyNode
 
 
 class SaySomething(ClientIDMutation):
@@ -37,13 +43,13 @@ class OtherMutation(ClientIDMutation):
         additional_field = String()
 
     name = String()
-    my_node_edge = Field(MyNode.Connection.Edge)
+    my_node_edge = Field(MyNodeConnection.Edge)
 
     @classmethod
     def mutate_and_get_payload(cls, args, context, info):
         shared = args.get('shared', '')
         additionalField = args.get('additionalField', '')
-        edge_type = MyNode.Connection.Edge
+        edge_type = MyNodeConnection.Edge
         return OtherMutation(name=shared + additionalField,
                              my_node_edge=edge_type(
                                  cursor='1', node=MyNode(name='name')))

--- a/graphene/relay/tests/test_node.py
+++ b/graphene/relay/tests/test_node.py
@@ -52,15 +52,6 @@ def test_node_good():
     assert 'id' in MyNode._meta.fields
 
 
-def test_node_get_connection():
-    connection = MyNode.Connection
-    assert issubclass(connection, Connection)
-
-
-def test_node_get_connection_dont_duplicate():
-    assert MyNode.Connection == MyNode.Connection
-
-
 def test_node_query():
     executed = schema.execute(
         '{ node(id:"%s") { ... on MyNode { name } } }' % to_global_id("MyNode", 1)

--- a/graphene/types/interface.py
+++ b/graphene/types/interface.py
@@ -56,7 +56,3 @@ class Interface(six.with_metaclass(InterfaceMeta)):
 
     def __init__(self, *args, **kwargs):
         raise Exception("An Interface cannot be intitialized")
-
-    @classmethod
-    def implements(cls, objecttype):
-        pass

--- a/graphene/types/objecttype.py
+++ b/graphene/types/objecttype.py
@@ -45,10 +45,6 @@ class ObjectTypeMeta(AbstractTypeMeta):
         )
 
         cls = type.__new__(cls, name, bases, dict(attrs, _meta=options))
-
-        for interface in options.interfaces:
-            interface.implements(cls)
-
         return cls
 
     def __str__(cls):  # noqa: N802


### PR DESCRIPTION
This PR improves the `relay.Connection` APIs in Graphene.
Is inspired on the work of @Globegitter in #288 and following #304.

Things that this PR should achieve:
* [x] Remove automatic `.Connection` creation in Nodes in pro of cleaner and more explicit code
* [ ] Remove the `graphql-relay` dependency.
* [ ] One connection type could have different resolving strategies (different cursors / In a fully list, in a iterable without an explicit length = django queryset, ...)

## Related issues
#304 #180 #62