### PR TITLE
Add link to official GraphQL docs in Getting Started 

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -1,6 +1,12 @@
 Getting started
 ===============
 
+What is GraphQL?
+----------------
+
+For an introduction to GraphQL and an overview of its concepts, please refer
+to `the official introduction <http://graphql.org/learn/>`.
+
 Let’s build a basic GraphQL schema from scratch.
 
 Requirements


### PR DESCRIPTION
I am contributing to the Graphene docs for the first time.  

This commit simply adds a reference to the official GraphQL docs - I haven't been able to build it locally due to graphql-python/graphene-python.org#8  but as it is a simple change, it should be ok.
