### PR TITLE
Add tox dependencies

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,9 @@ deps=
     blinker
     singledispatch
     mock
+    pytz
+    iso8601
+    pytest-benchmark
 setenv =
      PYTHONPATH = .:{envdir}
 commands=


### PR DESCRIPTION
Tox fails without pytz, iso8601 and pytest-benchmark