### PR TITLE
Make node arg options and default required to True for GlobalID.

### DIFF
--- a/graphene/relay/node.py
+++ b/graphene/relay/node.py
@@ -35,9 +35,9 @@ def get_default_connection(cls):
 
 class GlobalID(Field):
 
-    def __init__(self, node, *args, **kwargs):
-        super(GlobalID, self).__init__(ID, *args, **kwargs)
-        self.node = node
+    def __init__(self, node=None, required=True, *args, **kwargs):
+        super(GlobalID, self).__init__(ID, required=required, *args, **kwargs)
+        self.node = node or Node
 
     @staticmethod
     def id_resolver(parent_resolver, node, root, args, context, info):
@@ -52,7 +52,7 @@ class NodeMeta(InterfaceMeta):
 
     def __new__(cls, name, bases, attrs):
         cls = InterfaceMeta.__new__(cls, name, bases, attrs)
-        cls._meta.fields['id'] = GlobalID(cls, required=True, description='The ID of the object.')
+        cls._meta.fields['id'] = GlobalID(cls, description='The ID of the object.')
         return cls
 
 

--- a/graphene/relay/tests/test_global_id.py
+++ b/graphene/relay/tests/test_global_id.py
@@ -1,0 +1,22 @@
+from ..node import Node, GlobalID
+
+from ...types import NonNull, ID
+
+
+class CustomNode(Node):
+
+    class Meta:
+        name = 'Node'
+
+
+def test_global_id_defaults_to_required_and_node():
+    gid = GlobalID()
+    assert isinstance(gid.type, NonNull)
+    assert gid.type.of_type == ID
+    assert gid.node == Node
+
+
+def test_global_id_allows_overriding_of_node_and_required():
+    gid = GlobalID(node=CustomNode, required=False)
+    assert gid.type == ID
+    assert gid.node == CustomNode


### PR DESCRIPTION
This is pulling out some bits of #282 to make it a focused PR just trying to fix one thing. See discussion in in #282. We are most of the time overriding `GlobalID` and so it just makes it far less clean having to write `GlobalID(node=Node, required=True)` all the time, also somewhat surprising, as it was an undocumented breaking change between `0.x` and `1.x`.

Let me know if there are still any issues with that :)