### PR TITLE
Add OmniScalar type

### DIFF
--- a/graphene/__init__.py
+++ b/graphene/__init__.py
@@ -60,6 +60,7 @@ if not __SETUP__:
         'Float',
         'Enum',
         'Boolean',
+        'OmniScalar',
         'List',
         'NonNull',
         'Argument',

--- a/graphene/__init__.py
+++ b/graphene/__init__.py
@@ -26,7 +26,7 @@ if not __SETUP__:
         InputField,
         Schema,
         Scalar,
-        String, ID, Int, Float, Boolean,
+        String, ID, Int, Float, Boolean, OmniScalar,
         List, NonNull,
         Enum,
         Argument,

--- a/graphene/types/__init__.py
+++ b/graphene/types/__init__.py
@@ -4,7 +4,7 @@ from .objecttype import ObjectType
 from .abstracttype import AbstractType
 from .interface import Interface
 from .mutation import Mutation
-from .scalars import Scalar, String, ID, Int, Float, Boolean
+from .scalars import Scalar, String, ID, Int, Float, Boolean, OmniScalar
 from .schema import Schema
 from .structures import List, NonNull
 from .enum import Enum
@@ -32,6 +32,7 @@ __all__ = [
     'Int',
     'Float',
     'Boolean',
+    'OmniScalar',
     'List',
     'NonNull',
     'Argument',

--- a/graphene/types/scalars.py
+++ b/graphene/types/scalars.py
@@ -175,11 +175,13 @@ class OmniScalar(Scalar):
 
     _scalar_type_map = {
         str: String,
-        unicode: String,
         bool: Boolean,
         int: Int,
         float: Float,
     }
+
+    if six.PY2:
+        _scalar_type_map[unicode] = String
 
     @staticmethod
     def serialize(value):

--- a/graphene/types/tests/test_scalars_serialization.py
+++ b/graphene/types/tests/test_scalars_serialization.py
@@ -1,4 +1,4 @@
-from ..scalars import Boolean, Float, Int, String
+from ..scalars import Boolean, Float, Int, String, OmniScalar
 
 
 def test_serializes_output_int():
@@ -48,3 +48,28 @@ def test_serializes_output_boolean():
     assert Boolean.serialize(0) is False
     assert Boolean.serialize(True) is True
     assert Boolean.serialize(False) is False
+
+
+def test_serializes_output_omniscalar():
+    # Int
+    assert OmniScalar.serialize(1) == 1
+    assert OmniScalar.serialize(0) == 0
+    assert OmniScalar.serialize(-1) == -1
+    # Float
+    assert OmniScalar.serialize(0.1) == 0.1
+    assert OmniScalar.serialize(1.1) == 1.1
+    assert OmniScalar.serialize(-1.1) == -1.1
+    # String
+    assert OmniScalar.serialize('string') == 'string'
+    assert OmniScalar.serialize(u'\U0001F601') == u'\U0001F601'
+    # Boolean
+    assert OmniScalar.serialize(False) is False
+    assert OmniScalar.serialize(True) is True
+    # Other
+    assert OmniScalar.serialize(None) is None
+    assert OmniScalar.serialize([]) is None
+    assert OmniScalar.serialize({}) is None
+    assert OmniScalar.serialize(object()) is None
+    assert OmniScalar.serialize(object) is None
+    assert OmniScalar.serialize(lambda _: '') is None
+


### PR DESCRIPTION
Using the OmniScalar type, you can define a field where the scalar type is nondeterministic.  For example, take this Elasticsearch term aggregation on the `_type` and `year` fields in the index:

```
{
  "_type": {
    "buckets": [
      {
        "key": "article",
        "doc_count": 367086
      },
      {
        "key": "video",
        "doc_count": 40046
      }
    ],
    "sum_other_doc_count": 0,
    "doc_count_error_upper_bound": 0
  },
  "year": {
    "buckets": [
      {
        "key": 2015,
        "doc_count": 2963
      },
      {
        "key": 2016,
        "doc_count": 2059
      }
    ],
    "sum_other_doc_count": 357862,
    "doc_count_error_upper_bound": 614
  }
}
```

The `key` field is either a `String` or an `Int` depending on how it was mapped in Elasticsearch.  We'd like to make the aggregations part of the GraphQL schema, so instead of requiring the developer to define a union of object types with varying scalars for the `key` field, we simplify the schema by declaring only `key = OmniScalar()`.
