### PR TITLE
(relay connection) promisify result from async method

### DIFF
--- a/graphene/relay/connection.py
+++ b/graphene/relay/connection.py
@@ -12,6 +12,7 @@ from ..types import (AbstractType, Boolean, Enum, Int, Interface, List, NonNull,
 from ..types.field import Field
 from ..types.objecttype import ObjectType, ObjectTypeMeta
 from ..types.options import Options
+from ..utils.compat_asyncio_promise import promisify
 from ..utils.is_base_type import is_base_type
 from ..utils.props import props
 from .node import is_node
@@ -139,7 +140,7 @@ class IterableConnectionField(Field):
 
     @classmethod
     def connection_resolver(cls, resolver, connection_type, root, args, context, info):
-        resolved = resolver(root, args, context, info)
+        resolved = promisify(resolver(root, args, context, info))
 
         on_resolve = partial(cls.resolve_connection, connection_type, args)
         if isinstance(resolved, Promise):

--- a/graphene/utils/compat_asyncio_promise.py
+++ b/graphene/utils/compat_asyncio_promise.py
@@ -1,0 +1,12 @@
+import promise
+
+def promisify(resolved):
+    try:
+        import asyncio
+        if isinstance(resolved, asyncio.Future) or \
+            asyncio.iscoroutine(resolved):
+            return promise.promisify(resolved)
+    except:
+        pass
+
+    return resolved


### PR DESCRIPTION
With the current state of Graphene, is it not possible to use an `async` method as a **resolver**.

**Reason**:

The resolver can not handle coroutine, it works only with expected data type and also [with "Promise" object](https://github.com/graphql-python/graphene/blob/master/graphene/relay/connection.py#L145).

**Error message**:

```
AssertionError: Resolved value from the connection field have to be iterable or instance of PeopleConnection. Received "<coroutine object About.resolve_people at 0x7faad9c93a40>"
```

**Example**:

So, if you try with this piece of code

```python
import graphene
from graphene import relay

class Person(graphene.ObjectType):
    name = graphene.String()


class PeopleConnection(graphene.Connection):
    class Meta:
        node = Person


class About(graphene.ObjectType):
    class Meta:
        interfaces = (relay.Node, )

    people = relay.ConnectionField(PeopleConnection)

    @classmethod
    def get_node(cls, *_):
        return {}

    async def resolve_people(self, args, ctx, *_):
        return [People(name="Steve")]
```

You will get this error:
```
AssertionError: Resolved value from the connection field have to be iterable or instance of PeopleConnection. Received "<coroutine object About.resolve_people at 0x7faad9c93a40>"
```

**Suggested method:**

Update `connection_resolver` in relay/connection module to promisify async methods.