### PR TITLE
Refactored mounted types logic

### DIFF
--- a/graphene/types/argument.py
+++ b/graphene/types/argument.py
@@ -1,12 +1,12 @@
 from collections import OrderedDict
 from itertools import chain
 
-from ..utils.orderedtype import OrderedType
+from .mountedtype import MountedType
 from .structures import NonNull
 from .dynamic import Dynamic
 
 
-class Argument(OrderedType):
+class Argument(MountedType):
 
     def __init__(self, type, default_value=None, description=None, name=None, required=False, _creation_counter=None):
         super(Argument, self).__init__(_creation_counter=_creation_counter)
@@ -47,7 +47,7 @@ def to_arguments(args, extra_args=None):
                 continue
 
         if isinstance(arg, UnmountedType):
-            arg = arg.Argument()
+            arg = Argument.mount(arg)
 
         if isinstance(arg, (InputField, Field)):
             raise ValueError('Expected {} to be Argument, but received {}. Try using Argument({}).'.format(

--- a/graphene/types/dynamic.py
+++ b/graphene/types/dynamic.py
@@ -1,9 +1,9 @@
 import inspect
 
-from ..utils.orderedtype import OrderedType
+from .mountedtype import MountedType
 
 
-class Dynamic(OrderedType):
+class Dynamic(MountedType):
     '''
     A Dynamic Type let us get the type in runtime when we generate
     the schema. So we can have lazy fields.

--- a/graphene/types/field.py
+++ b/graphene/types/field.py
@@ -2,8 +2,8 @@ import inspect
 from collections import Mapping, OrderedDict
 from functools import partial
 
-from ..utils.orderedtype import OrderedType
 from .argument import Argument, to_arguments
+from .mountedtype import MountedType
 from .structures import NonNull
 from .unmountedtype import UnmountedType
 
@@ -18,7 +18,7 @@ def source_resolver(source, root, args, context, info):
     return resolved
 
 
-class Field(OrderedType):
+class Field(MountedType):
 
     def __init__(self, type, args=None, resolver=None, source=None,
                  deprecation_reason=None, name=None, description=None,

--- a/graphene/types/inputfield.py
+++ b/graphene/types/inputfield.py
@@ -1,8 +1,8 @@
-from ..utils.orderedtype import OrderedType
+from .mountedtype import MountedType
 from .structures import NonNull
 
 
-class InputField(OrderedType):
+class InputField(MountedType):
 
     def __init__(self, type, name=None, default_value=None,
                  deprecation_reason=None, description=None,

--- a/graphene/types/mountedtype.py
+++ b/graphene/types/mountedtype.py
@@ -1,0 +1,21 @@
+from ..utils.orderedtype import OrderedType
+from .unmountedtype import UnmountedType
+
+
+class MountedType(OrderedType):
+
+    @classmethod
+    def mount(cls, unmounted):  # noqa: N802
+        '''
+        Mount the UnmountedType instance
+        '''
+        assert isinstance(unmounted, UnmountedType), (
+            '{} can\'t mount {}'
+        ).format(cls.__name__, repr(unmounted))
+
+        return cls(
+            unmounted.get_type(),
+            *unmounted.args,
+            _creation_counter=unmounted.creation_counter,
+            **unmounted.kwargs
+        )

--- a/graphene/types/unmountedtype.py
+++ b/graphene/types/unmountedtype.py
@@ -27,41 +27,29 @@ class UnmountedType(OrderedType):
         '''
         raise NotImplementedError("get_type not implemented in {}".format(self))
 
+    def mount_as(self, _as):
+        return _as.mount(self)
+
     def Field(self):  # noqa: N802
         '''
         Mount the UnmountedType as Field
         '''
         from .field import Field
-        return Field(
-            self.get_type(),
-            *self.args,
-            _creation_counter=self.creation_counter,
-            **self.kwargs
-        )
+        return self.mount_as(Field)
 
     def InputField(self):  # noqa: N802
         '''
         Mount the UnmountedType as InputField
         '''
         from .inputfield import InputField
-        return InputField(
-            self.get_type(),
-            *self.args,
-            _creation_counter=self.creation_counter,
-            **self.kwargs
-        )
+        return self.mount_as(InputField)
 
     def Argument(self):  # noqa: N802
         '''
         Mount the UnmountedType as Argument
         '''
         from .argument import Argument
-        return Argument(
-            self.get_type(),
-            *self.args,
-            _creation_counter=self.creation_counter,
-            **self.kwargs
-        )
+        return self.mount_as(Argument)
 
     def __eq__(self, other):
         return (

--- a/graphene/types/utils.py
+++ b/graphene/types/utils.py
@@ -1,8 +1,6 @@
 from collections import OrderedDict
 
-from .dynamic import Dynamic
-from .field import Field
-from .inputfield import InputField
+from .mountedtype import MountedType
 from .unmountedtype import UnmountedType
 
 
@@ -35,34 +33,16 @@ def get_base_fields(bases, _as=None):
     return fields
 
 
-def mount_as(unmounted_field, _as):
-    '''
-    Mount the UnmountedType dinamically as Field or InputField
-    '''
-    if _as is None:
-        return unmounted_field
-
-    elif _as is Field:
-        return unmounted_field.Field()
-
-    elif _as is InputField:
-        return unmounted_field.InputField()
-
-    raise Exception(
-        'Unmounted field "{}" cannot be mounted in {}.'.format(
-            unmounted_field, _as
-        )
-    )
-
-
 def get_field_as(value, _as=None):
     '''
     Get type mounted
     '''
-    if isinstance(value, (Field, InputField, Dynamic)):
+    if isinstance(value, MountedType):
         return value
     elif isinstance(value, UnmountedType):
-        return mount_as(value, _as)
+        if _as is None:
+            return value
+        return _as.mount(value)
 
 
 def yank_fields_from_attrs(attrs, _as=None, delete=True, sort=True):


### PR DESCRIPTION
This PR refactors the `UnmountedType`s mounting logic adding a `MountedType` that simplifies the implementation and permits more extensibility.