### PR TITLE
Allow custom mounted classes

### DIFF
--- a/graphene/types/mountedtype.py
+++ b/graphene/types/mountedtype.py
@@ -4,6 +4,8 @@ from .unmountedtype import UnmountedType
 
 class MountedType(OrderedType):
 
+    _mount_cls_override = None
+
     @classmethod
     def mount(cls, unmounted):  # noqa: N802
         '''
@@ -13,7 +15,9 @@ class MountedType(OrderedType):
             '{} can\'t mount {}'
         ).format(cls.__name__, repr(unmounted))
 
-        return cls(
+        mount_cls = cls._mount_cls_override or cls
+
+        return mount_cls(
             unmounted.get_type(),
             *unmounted.args,
             _creation_counter=unmounted.creation_counter,

--- a/graphene/types/tests/test_mountedtype.py
+++ b/graphene/types/tests/test_mountedtype.py
@@ -1,0 +1,60 @@
+import pytest
+
+from ..mountedtype import MountedType
+from ..field import Field
+from ..objecttype import ObjectType
+from ..scalars import String
+
+
+class CustomField(Field):
+    def __init__(self, *args, **kwargs):
+        self.metadata = kwargs.pop('metadata', None)
+        super(CustomField, self).__init__(*args, **kwargs)
+
+
+def test_mounted_type():
+    unmounted = String()
+    mounted = Field.mount(unmounted)
+    assert isinstance(mounted, Field)
+    assert mounted.type == String
+
+
+def test_mounted_type_custom():
+    unmounted = String(metadata={'hey': 'yo!'})
+    mounted = CustomField.mount(unmounted)
+    assert isinstance(mounted, CustomField)
+    assert mounted.type == String
+    assert mounted.metadata == {'hey': 'yo!'}
+
+
+@pytest.yield_fixture
+def custom_field():
+    # We set the override
+    Field._mount_cls_override = CustomField
+
+    # Run the test
+    yield CustomField
+
+    # Remove the class override (back to the original state)
+    Field._mount_cls_override = None
+
+
+def test_mounted_type_overrided(custom_field):
+    # This function is using the custom_field yield fixture
+
+    unmounted = String(metadata={'hey': 'yo!'})
+    mounted = Field.mount(unmounted)
+    assert isinstance(mounted, CustomField)
+    assert mounted.type == String
+    assert mounted.metadata == {'hey': 'yo!'}
+
+
+def test_mounted_type_overrided(custom_field):
+    # This function is using the custom_field yield fixture
+
+    class Query(ObjectType):
+        test = String(metadata={'other': 'thing'})
+
+    test_field = Query._meta.fields['test']
+    assert isinstance(test_field, CustomField)
+    assert test_field.metadata == {'other': 'thing'}


### PR DESCRIPTION
This PR implements the same functionality as #366 (thanks to the recent merged PR #391, which enables more complex mounting behaviors).

## Usage

Setup:

```python
from graphene import Field, InputField, Argument

class Metadata(object):
    def __init__(self, *args, **kwargs):
        self.metadata = kwargs.pop('metadata', None)
        super(Metadata, self).__init__(*args, **kwargs)

class CustomField(Metadata, Field): pass
class CustomInputField(Metadata, InputField): pass
class CustomArgument(Metadata, Field): pass

Field._mount_cls_override = CustomField
InputField._mount_cls_override = CustomInputField
Argument._mount_cls_override = CustomArgument
```

*Note that all this code have to run before any `ObjectType` or `Interface` is declared.*

Usage:
```python
class Query(ObjectType):
    test = String(metadata={'other': 'thing'})

assert Query._meta.fields['test'].metadata['other'] == 'thing'
```

@Globegitter