### PR TITLE
Allow class methods to be used as a field source

### DIFF
--- a/graphene/types/field.py
+++ b/graphene/types/field.py
@@ -13,7 +13,7 @@ base_type = type
 
 def source_resolver(source, root, args, context, info):
     resolved = getattr(root, source, None)
-    if inspect.isfunction(resolved):
+    if inspect.isfunction(resolved) or inspect.ismethod(resolved):
         return resolved()
     return resolved
 

--- a/graphene/types/tests/test_field.py
+++ b/graphene/types/tests/test_field.py
@@ -10,6 +10,9 @@ class MyInstance(object):
     value = 'value'
     value_func = staticmethod(lambda: 'value_func')
 
+    def value_method(self):
+        return 'value_method'
+
 
 def test_field_basic():
     MyType = object()
@@ -74,6 +77,12 @@ def test_field_source_func():
     MyType = object()
     field = Field(MyType, source='value_func')
     assert field.resolver(MyInstance(), {}, None, None) == MyInstance.value_func()
+
+
+def test_field_source_method():
+    MyType = object()
+    field = Field(MyType, source='value_method')
+    assert field.resolver(MyInstance(), {}, None, None) == MyInstance().value_method()
 
 
 def test_field_source_as_argument():


### PR DESCRIPTION
Static methods are currently working, but it can be useful to allow class methods to work also, particularly in the context of django-graphene and using DjangoObjectType where you may have properties or methods on fatter models.