### PR TITLE
Fixed indent in mutation docs

### DIFF
--- a/docs/types/mutations.rst
+++ b/docs/types/mutations.rst
@@ -10,20 +10,20 @@ This example defines a Mutation:
 
 .. code:: python
 
-import graphene
+    import graphene
 
-class CreatePerson(graphene.Mutation):
-    class Input:
-        name = graphene.String()
+    class CreatePerson(graphene.Mutation):
+        class Input:
+            name = graphene.String()
 
-    ok = graphene.Boolean()
-    person = graphene.Field(lambda: Person)
+        ok = graphene.Boolean()
+        person = graphene.Field(lambda: Person)
 
-    @staticmethod
-    def mutate(root, args, context, info):
-        person = Person(name=args.get('name'))
-        ok = True
-        return CreatePerson(person=person, ok=ok)
+        @staticmethod
+        def mutate(root, args, context, info):
+            person = Person(name=args.get('name'))
+            ok = True
+            return CreatePerson(person=person, ok=ok)
 
 **person** and **ok** are the output fields of the Mutation when is
 resolved.


### PR DESCRIPTION
Not sure what the contribution requirements are for documentation. I noticed that this page: <http://docs.graphene-python.org/en/latest/types/mutations/> was a bit off.

Feel free to close PR and fix it in the "proper" way if applicable. I think this is sufficient as the README in the "graphene-python.org-docs.zip" said it was auto-generated everytime.