### PR TITLE
Add documentation about Graphene + Apollo

### DIFF
--- a/docs/apollo/batching.rst
+++ b/docs/apollo/batching.rst
@@ -20,7 +20,7 @@ Graphene-Django has built-in support for transport batching, which can be enable
     from graphene_django.views import GraphQLView
 
     urlpatterns = [
-        url(r'^graphql', GraphQLView.as_view(graphiql=True, batch=True)),
+        url(r'^graphql', GraphQLView.as_view(batch=True)),
     ]
 
 

--- a/docs/apollo/batching.rst
+++ b/docs/apollo/batching.rst
@@ -1,0 +1,28 @@
+Batching
+=====
+
+Apollo Client has a network interface that supports `GraphQL transport batching`_.
+
+Transport batching is used to batch requests together that would otherwise be sent individually.
+This not only saves client and server resources but also enables more efficient batching and caching for requests between the GraphQL server and databases or storage services.
+
+
+Setting up batching in Graphene-Django
+--------------------------------------
+
+Graphene-Django has built-in support for transport batching, which can be enabled by simply passing ``batch=true`` to your ``GraphQLView``: 
+
+.. code:: python
+
+    from django.conf.urls import url, include
+    from django.contrib import admin
+
+    from graphene_django.views import GraphQLView
+
+    urlpatterns = [
+        url(r'^graphql', GraphQLView.as_view(graphiql=True, batch=True)),
+    ]
+
+
+
+.. _GraphQL transport batching: http://dev.apollodata.com/core/network.html#query-batching

--- a/docs/apollo/index.rst
+++ b/docs/apollo/index.rst
@@ -1,0 +1,31 @@
+Apollo
+======
+
+`Apollo`_ is an open source GraphQL client that has integrations for `React`_, `Angular`_, `Ember`_, `Vue`_, and other frontend view layers.
+It has implementations in Swift and Java for `iOS`_ and `Android`_ respectively.
+Graphene works with Apollo out of the box, and also supports some of its more advanced features like batching.
+
+
+.. toctree::
+   :maxdepth: 2
+
+   batching
+
+
+Useful links
+------------
+
+- `Apollo documentation`_
+- `Apollo Client Developer Tools`_
+- `Apollo React + GraphQL tutorial`_
+
+.. _Apollo: https://github.io/apollostack/apollo-client/
+.. _Apollo documentation: http://dev.apollodata.com/
+.. _React: https://github.com/apollographql/react-apollo
+.. _Angular: https://github.com/apollographql/apollo-angular
+.. _Vue: https://github.com/Akryum/vue-apollo
+.. _Ember: https://github.com/bgentry/ember-apollo-client
+.. _iOS: https://github.com/apollographql/apollo-ios
+.. _Android: https://github.com/apollographql/apollo-android
+.. _Apollo React + GraphQL tutorial: https://dev-blog.apollodata.com/full-stack-react-graphql-tutorial-582ac8d24e3b
+.. _Apollo Client Developer Tools: https://dev-blog.apollodata.com/apollo-client-developer-tools-ff89181ebcf

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,6 +10,7 @@ Contents:
    types/index
    execution/index
    relay/index
+   apollo/index
 
 Integrations
 -----


### PR DESCRIPTION
Hi @syrusakbary, I've added a section about Apollo with useful links and instructions for how to set up batching to the docs. I think this will go a long way in ensuring that people don't get confused about whether Graphene works with Apollo or not 🙂 