### PR TITLE
fix typo in docs/execution

### DIFF
--- a/docs/execution/execute.rst
+++ b/docs/execution/execute.rst
@@ -6,11 +6,11 @@ For executing a query a schema, you can directly call the ``execute`` method on 
 
 
 .. code:: python
-    
+
     schema = graphene.Schema(...)
     result = schema.execute('{ name }')
 
-``result`` represents he result of execution. ``result.data`` is the result of executing the query, ``result.errors`` is ``None`` if no errors occurred, and is a non-empty list if an error occurred.
+``result`` represents the result of execution. ``result.data`` is the result of executing the query, ``result.errors`` is ``None`` if no errors occurred, and is a non-empty list if an error occurred.
 
 
 Context
@@ -26,7 +26,7 @@ You can pass context to a query via ``context_value``.
 
         def resolve_name(self, args, context, info):
             return context.get('name')
-    
+
     schema = graphene.Schema(Query)
     result = schema.execute('{ name }', context_value={'name': 'Syrus'})
 


### PR DESCRIPTION
`he` -> `the`.

Those tabs removal might not be necessary. Request to undo as you want.