### PR TITLE
Update to_camel_case to handle leading and double-underscores.

### DIFF
--- a/graphene/utils/str_converters.py
+++ b/graphene/utils/str_converters.py
@@ -5,7 +5,7 @@ def to_camel_case(snake_str):
     """
     Return a camel-cased version of a snake-cased string.
 
-    Leading underscores and multiple-underscores are kept
+    Leading underscores and multiple consecutive underscores are kept
     intact.
 
     :param snake_str: A snake-cased string.
@@ -16,13 +16,13 @@ def to_camel_case(snake_str):
     # component.
     snake_case_sub_strings = re.findall(r'(_*[a-zA-Z]+|_+$)', snake_str)
 
-    # The first variable is unchanged case wise (and leading
+    # The first variable is unchanged case-wise (and leading
     # underscores preserved as-is).
     camel_case_sub_strings = [snake_case_sub_strings[0]]
 
     for s in snake_case_sub_strings[1:]:
         # We reset the camel casing algorithm if more than one
-        # underscore is encountered.  The endwiths handles any
+        # underscore is encountered.  The endswith handles any
         # trailing underscores in the original snake-cased
         # variable.
         if s.startswith('__') or s.endswith('_'):

--- a/graphene/utils/str_converters.py
+++ b/graphene/utils/str_converters.py
@@ -4,10 +4,10 @@ import re
 def to_camel_case(snake_str):
     """
     Return a camel-cased version of a snake-cased string.
-    
+
     Leading underscores and multiple-underscores are kept
     intact.
-    
+
     :param snake_str: A snake-cased string.
     :return: A camel-cased string.
     """
@@ -29,10 +29,11 @@ def to_camel_case(snake_str):
             camel_case_sub_strings.append(s)
             continue
 
-        # Otherwise replace '_name' with 'Name', for example.
+        # Otherwise we replace '_name' with 'Name', for example.
         camel_case_sub_strings.append(s[1:].title())
 
     return ''.join(camel_case_sub_strings)
+
 
 # From this response in Stackoverflow
 # http://stackoverflow.com/a/1176023/1072990

--- a/graphene/utils/str_converters.py
+++ b/graphene/utils/str_converters.py
@@ -1,14 +1,35 @@
 import re
 
 
-# From this response in Stackoverflow
-# http://stackoverflow.com/a/19053800/1072990
 def to_camel_case(snake_str):
-    components = snake_str.split('_')
-    # We capitalize the first letter of each component except the first one
-    # with the 'title' method and join them together.
-    return components[0] + "".join(x.title() if x else '_' for x in components[1:])
+    """
+    Return a camel-cased version of a snake-cased string.
+    
+    Leading underscores and multiple-underscores are kept
+    intact.
+    
+    :param snake_str: A snake-cased string.
+    :return: A camel-cased string.
+    """
+    # Find all subcomponents in a snake-cased string, including
+    # any trailing underscores, which are treated as
+    snake_case_sub_strings = re.findall(r'(_*[a-zA-Z]+|_+$)', snake_str)
 
+    # The first variable is unchanged case wise.
+    camel_case_sub_strings = [snake_case_sub_strings[0]]
+
+    for s in snake_case_sub_strings[1:]:
+        # We reset the camel casing algorithm if more than one
+        # underscore is encountered, and do nothing for trailing
+        # unscores at the end of the snake-cased variable.
+        if s.startswith('__') or s.endswith('_'):
+            camel_case_sub_strings.append(s)
+            continue
+
+        # Otherwise replace '_name' with 'Name', for example.
+        camel_case_sub_strings.append(s[1:].title())
+
+    return ''.join(camel_case_sub_strings)
 
 # From this response in Stackoverflow
 # http://stackoverflow.com/a/1176023/1072990

--- a/graphene/utils/str_converters.py
+++ b/graphene/utils/str_converters.py
@@ -12,16 +12,19 @@ def to_camel_case(snake_str):
     :return: A camel-cased string.
     """
     # Find all subcomponents in a snake-cased string, including
-    # any trailing underscores, which are treated as
+    # any trailing underscores, which are treated as a separate
+    # component.
     snake_case_sub_strings = re.findall(r'(_*[a-zA-Z]+|_+$)', snake_str)
 
-    # The first variable is unchanged case wise.
+    # The first variable is unchanged case wise (and leading
+    # underscores preserved as-is).
     camel_case_sub_strings = [snake_case_sub_strings[0]]
 
     for s in snake_case_sub_strings[1:]:
         # We reset the camel casing algorithm if more than one
-        # underscore is encountered, and do nothing for trailing
-        # unscores at the end of the snake-cased variable.
+        # underscore is encountered.  The endwiths handles any
+        # trailing underscores in the original snake-cased
+        # variable.
         if s.startswith('__') or s.endswith('_'):
             camel_case_sub_strings.append(s)
             continue

--- a/graphene/utils/tests/test_str_converters.py
+++ b/graphene/utils/tests/test_str_converters.py
@@ -14,8 +14,12 @@ def test_snake_case():
 
 def test_camel_case():
     assert to_camel_case('snakes_on_a_plane') == 'snakesOnAPlane'
-    assert to_camel_case('snakes_on_a__plane') == 'snakesOnA_Plane'
+    assert to_camel_case('snakes_on_a__plane') == 'snakesOnA__plane'
     assert to_camel_case('i_phone_hysteria') == 'iPhoneHysteria'
+    assert to_camel_case('i_phone_hysteria_') == 'iPhoneHysteria_'
+    assert to_camel_case('_i_phone_hysteria') == '_iPhoneHysteria'
+    assert to_camel_case('__i_phone_hysteria') == '__iPhoneHysteria'
+    assert to_camel_case('__all__') == '__all__'
 
 
 def test_to_const():


### PR DESCRIPTION
### CHANGE SUMMARY

* Update `to_camel_case` to more gracefully handle multiple-underscore separators and leading underscores.

### NOTES

The current behavior is somewhat unintuitive.  For example:

```python
In [2]: to_camel_case('__all__')
Out[2]: '_All__'
```
The arbitrary removal of a single underscore is awkward.  I argue it makes more intuitive sense, at least in the way snake case variables are typically used, to treat single underscores specifically, and leave multiple underscores untouched.  (In my implementation they also 'reset' the camel casing, but that's more debatable.)

I've modified the code to change a couple of things:

* Leading underscores are left in place.  (`_all` remains `_all` and `_all_x` becomes `_allX`).
* Multiple underscores are not treated as snake case separators, and are, instead, left in place. Further snake case variable components following them are handled as if they were separate variables themselves in terms of conversion.  (`my__var_name` becomes `my__varName` not `my__VarName` -- though this is easy to change.)

*I'm open to feedback on any of these assumptions.  I think the most important change is preserving the leading underscores in a sensible way.*

