### PR TITLE
Fix doc typo

### DIFF
--- a/docs/types/objecttypes.rst
+++ b/docs/types/objecttypes.rst
@@ -52,7 +52,7 @@ field is the ``resolve_{field_name}`` method on the ``ObjectType``.
 
 By default resolvers take the arguments ``args``, ``context`` and ``info``.
 
-NOTE: The resolvers on a ``ObjectType`` are always treated as ``staticmethods``,
+NOTE: The resolvers on a ``ObjectType`` are always treated as ``staticmethod``\ s,
 so the first argument to the resolver method ``self`` (or ``root``) need
 not be an actual instance of the ``ObjectType``.
 

--- a/docs/types/objecttypes.rst
+++ b/docs/types/objecttypes.rst
@@ -52,7 +52,7 @@ field is the ``resolve_{field_name}`` method on the ``ObjectType``.
 
 By default resolvers take the arguments ``args``, ``context`` and ``info``.
 
-NOTE: The resolvers on a ``ObjectType`` are always treated as ``staticmethod``s,
+NOTE: The resolvers on a ``ObjectType`` are always treated as ``staticmethods``,
 so the first argument to the resolver method ``self`` (or ``root``) need
 not be an actual instance of the ``ObjectType``.
 


### PR DESCRIPTION
Original:

<img width="856" alt="screen shot 2017-07-11 at 11 12 36 am" src="https://user-images.githubusercontent.com/7938748/28049409-e7724e3e-6629-11e7-954a-cc33176facca.png">

Fixed:

<img width="877" alt="screen shot 2017-07-11 at 11 10 52 am" src="https://user-images.githubusercontent.com/7938748/28049375-a405ac04-6629-11e7-9fa5-5b454ad6379b.png">




