### PR TITLE
Add totalCount field in ConnectionBase class

### DIFF
--- a/graphene/relay/connection.py
+++ b/graphene/relay/connection.py
@@ -82,7 +82,12 @@ class ConnectionMeta(ObjectTypeMeta):
 
         class ConnectionBase(AbstractType):
             page_info = Field(PageInfo, name='pageInfo', required=True)
+            total_count = Int(name='totalCount', required=True)
             edges = NonNull(List(edge))
+
+            @staticmethod
+            def resolve_total_count(root, args, context, info):
+                return root.length
 
         bases = (ConnectionBase, ) + bases
         attrs = dict(attrs, _meta=options, Edge=edge)

--- a/graphene/relay/tests/test_connection.py
+++ b/graphene/relay/tests/test_connection.py
@@ -23,7 +23,7 @@ def test_connection():
 
     assert MyObjectConnection._meta.name == 'MyObjectConnection'
     fields = MyObjectConnection._meta.fields
-    assert list(fields.keys()) == ['page_info', 'edges', 'extra']
+    assert list(fields.keys()) == ['page_info', 'total_count', 'edges', 'extra']
     edge_field = fields['edges']
     pageinfo_field = fields['page_info']
 
@@ -48,7 +48,7 @@ def test_connection_inherit_abstracttype():
 
     assert MyObjectConnection._meta.name == 'MyObjectConnection'
     fields = MyObjectConnection._meta.fields
-    assert list(fields.keys()) == ['page_info', 'edges', 'extra']
+    assert list(fields.keys()) == ['page_info', 'total_count', 'edges', 'extra']
 
 
 def test_edge():


### PR DESCRIPTION
Add field totalCount in ConnectionBase class.
According to the official documentation of Graphql, the first level of pagination should be the totalCount parameter, which in graphenee is not yet available. This field is very useful and will make life much easier. I ask to include it in the main turnip, or to correct it. It seems that I did a little differently than in the general form of this repository, but in which case I will finalize it when I receive feedback.
