### PR TITLE
Fix bug with "private" attrs

### DIFF
--- a/graphene/types/objecttype.py
+++ b/graphene/types/objecttype.py
@@ -107,7 +107,7 @@ class ObjectType(six.with_metaclass(ObjectTypeMeta)):
         if kwargs:
             for prop in list(kwargs):
                 try:
-                    if isinstance(getattr(self.__class__, prop), property) or prop.startswith('_'):
+                    if prop.startswith('_') or isinstance(getattr(self.__class__, prop), property):
                         setattr(self, prop, kwargs.pop(prop))
                 except AttributeError:
                     pass


### PR DESCRIPTION
I believe this is a bug but I'm not actually sure of the desired intentions of underscore prefixed kwargs.

When you pass an underscore kwargs, this currently raises an AttributeError because of the first conditional. The fix is to swap these conditionals to allow for setting of underscore attributes.

The way I'm using these is to set a private variable to be used in a resolver to fetch a first class resource. I'm not sure if that's the intended use case or if there's a better way to do that.