### PR TITLE
Allow custom Meta attributes in subclasses of Interface

### DIFF
--- a/graphene/types/interface.py
+++ b/graphene/types/interface.py
@@ -16,12 +16,19 @@ class InterfaceMeta(AbstractTypeMeta):
         if not is_base_type(bases, InterfaceMeta):
             return type.__new__(cls, name, bases, attrs)
 
-        options = Options(
-            attrs.pop('Meta', None),
+        _meta = attrs.pop('_meta', None)
+        defaults = dict(
             name=name,
             description=trim_docstring(attrs.get('__doc__')),
             local_fields=None,
         )
+        if not _meta:
+            options = Options(
+                attrs.pop('Meta', None),
+                **defaults
+            )
+        else:
+            options = _meta.extend_with_defaults(defaults)
 
         options.base_fields = get_base_fields(bases, _as=Field)
 


### PR DESCRIPTION
Similar to ObjectType we want to subclass Interface and add more Meta attributes. The usecase is to create SQLAlchemyInterface which will map model fields to the interface (useful when the database represents structures with inheritance)