### PR TITLE
Add isinstance check for Enum in default resolver

### DIFF
--- a/graphene/types/resolver.py
+++ b/graphene/types/resolver.py
@@ -1,5 +1,11 @@
+from .enum import PyEnum
+
+
 def attr_resolver(attname, default_value, root, info, **args):
-    return getattr(root, attname, default_value)
+    value = getattr(root, attname, default_value)
+    if isinstance(value, PyEnum):
+        return value.value
+    return value
 
 
 def dict_resolver(attname, default_value, root, info, **args):


### PR DESCRIPTION
This should fix https://github.com/graphql-python/graphene/issues/558 (at least for Python >= 3.4), by checking if the automatically resolved attribute is an Enum.