### PR TITLE
Propagate specific mutation description to the mutation schema

### DIFF
--- a/graphene/types/mutation.py
+++ b/graphene/types/mutation.py
@@ -77,5 +77,6 @@ class Mutation(ObjectType):
     @classmethod
     def Field(cls, *args, **kwargs):
         return Field(
-            cls._meta.output, args=cls._meta.arguments, resolver=cls._meta.resolver
+            cls._meta.output, args=cls._meta.arguments, resolver=cls._meta.resolver,
+            description=cls._meta.description
         )

--- a/graphene/types/tests/test_mutation.py
+++ b/graphene/types/tests/test_mutation.py
@@ -36,6 +36,7 @@ def test_generate_mutation_with_meta():
     assert MyMutation._meta.description == "Documentation"
     resolved = MyMutation.Field().resolver(None, None, name='Peter')
     assert resolved == {'name': 'Peter'}
+    assert MyMutation.Field().description == "Documentation"
 
 
 def test_mutation_raises_exception_if_no_mutate():


### PR DESCRIPTION
Currently, mutation meta description is not displayed in the schema. This fix will juste set the description in the created Field.
