### PR TITLE
Pin versions of upstream requirements for 1.4.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -82,9 +82,9 @@ setup(
 
     install_requires=[
         'six>=1.10.0',
-        'graphql-core>=1.1',
-        'graphql-relay>=0.4.5',
-        'promise>=2.0',
+        'graphql-core==1.1',
+        'graphql-relay==0.4.5',
+        'promise==2.0.2',
     ],
     tests_require=tests_require,
     extras_require={


### PR DESCRIPTION
**Warning:** Obviously this cannot be merged. 

Not even sure what the strategy would be here but old Graphene releases prior to 2.0 are now completely broken since these versions were not pinned.

Long story short, because `graphql-core` is new and this package looks for `>=` 1.1, it takes 2.0 and breaks. 

My branch is a working copy of 1.4.1. If you still rely on 1.4.1 in production and haven't been able to dedicate time to upgrade your code for 2.0, this will work.

    pip install https://github.com/whalesalad/graphene/archive/v1-4-1.zip

You can either upgrade to 2.0 or use this for the time being.