### PR TITLE
Prevent requirement breaking changes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -86,10 +86,10 @@ setup(
     packages=find_packages(exclude=['tests', 'tests.*']),
 
     install_requires=[
-        'six>=1.10.0',
-        'graphql-core>=2.0',
-        'graphql-relay>=0.4.5',
-        'promise>=2.1',
+        'six>=1.10.0,<2',
+        'graphql-core>=2.0,<3',
+        'graphql-relay>=0.4.5,<1',
+        'promise>=2.1,<3',
     ],
     tests_require=tests_require,
     extras_require={


### PR DESCRIPTION
I have a project still in 1.2.0 that has been broken in my last release since it used `'graphql-core>=1.0.1'` in the `install_requires`. Since `graphql-core` has released version 2.0 with breaking changes and there was no instruction to maintain version 1, it was included as a dependency. This prevents this situation for the future.