### PR TITLE
fix documentation to access to the request in Django

### DIFF
--- a/docs/relay/mutations.rst
+++ b/docs/relay/mutations.rst
@@ -48,7 +48,7 @@ Mutations can also accept files, that's how it will work with different integrat
         @classmethod
         def mutate_and_get_payload(cls, root, info, **input):
             # When using it in Django, context will be the request
-            files = context.FILES
+            files = info.context.FILES
             # Or, if used in Flask, context will be the flask global request
             # files = context.files
 


### PR DESCRIPTION
With the current documentation, I get after execution:
"graphql.error.located_error.GraphQLLocatedError: name 'context' is not defined"

I don't get any error after the correction I made (I haven't yet tried to upload a file…)