### PR TITLE
Support from_enum description lambda

### DIFF
--- a/graphene/types/enum.py
+++ b/graphene/types/enum.py
@@ -21,6 +21,7 @@ EnumType = type(PyEnum)
 
 class EnumOptions(BaseOptions):
     enum = None  # type: Enum
+    deprecation_reason = None
 
 
 class EnumMeta(SubclassWithMeta_Meta):
@@ -45,8 +46,9 @@ class EnumMeta(SubclassWithMeta_Meta):
         return super(EnumMeta, cls).__call__(*args, **kwargs)
         # return cls._meta.enum(*args, **kwargs)
 
-    def from_enum(cls, enum, description=None):  # noqa: N805
-        meta_class = type('Meta', (object,), {'enum': enum, 'description': description})
+    def from_enum(cls, enum, description=None, deprecation_reason=None):  # noqa: N805
+        description = description or enum.__doc__
+        meta_class = type('Meta', (object,), {'enum': enum, 'description': description, 'deprecation_reason': deprecation_reason})
         return type(meta_class.enum.__name__, (Enum,), {'Meta': meta_class})
 
 
@@ -56,8 +58,10 @@ class Enum(six.with_metaclass(EnumMeta, UnmountedType, BaseType)):
     def __init_subclass_with_meta__(cls, enum=None, **options):
         _meta = EnumOptions(cls)
         _meta.enum = enum or cls.__enum__
+        _meta.deprecation_reason = options.pop('deprecation_reason', None)
         for key, value in _meta.enum.__members__.items():
             setattr(cls, key, value)
+
         super(Enum, cls).__init_subclass_with_meta__(_meta=_meta, **options)
 
     @classmethod

--- a/graphene/types/enum.py
+++ b/graphene/types/enum.py
@@ -48,7 +48,12 @@ class EnumMeta(SubclassWithMeta_Meta):
 
     def from_enum(cls, enum, description=None, deprecation_reason=None):  # noqa: N805
         description = description or enum.__doc__
-        meta_class = type('Meta', (object,), {'enum': enum, 'description': description, 'deprecation_reason': deprecation_reason})
+        meta_dict = {
+            'enum': enum,
+            'description': description,
+            'deprecation_reason': deprecation_reason
+        }
+        meta_class = type('Meta', (object,), meta_dict)
         return type(meta_class.enum.__name__, (Enum,), {'Meta': meta_class})
 
 

--- a/graphene/types/tests/test_enum.py
+++ b/graphene/types/tests/test_enum.py
@@ -76,8 +76,11 @@ def test_enum_from_builtin_enum_accepts_lambda_description():
 
         return 'New Hope Episode' if value == Episode.NEWHOPE else 'Other'
 
+    def custom_deprecation_reason(value):
+        return 'meh' if value == Episode.NEWHOPE else None
+
     PyEpisode = PyEnum('PyEpisode', 'NEWHOPE,EMPIRE,JEDI')
-    Episode = Enum.from_enum(PyEpisode, description=custom_description)
+    Episode = Enum.from_enum(PyEpisode, description=custom_description, deprecation_reason=custom_deprecation_reason)
 
     class Query(ObjectType):
         foo = Episode()
@@ -90,6 +93,10 @@ def test_enum_from_builtin_enum_accepts_lambda_description():
     assert GraphQLPyEpisode[0].name == 'NEWHOPE' and GraphQLPyEpisode[0].description == 'New Hope Episode'
     assert GraphQLPyEpisode[1].name == 'EMPIRE' and GraphQLPyEpisode[1].description == 'Other'
     assert GraphQLPyEpisode[2].name == 'JEDI' and GraphQLPyEpisode[2].description == 'Other'
+
+    assert GraphQLPyEpisode[0].name == 'NEWHOPE' and GraphQLPyEpisode[0].deprecation_reason == 'meh'
+    assert GraphQLPyEpisode[1].name == 'EMPIRE' and GraphQLPyEpisode[1].deprecation_reason == None
+    assert GraphQLPyEpisode[2].name == 'JEDI' and GraphQLPyEpisode[2].deprecation_reason == None
 
 
 def test_enum_from_python3_enum_uses_enum_doc():


### PR DESCRIPTION
This Pr enhances graphene Enum support in a couple of ways:
1. if `description` for the enum wasn't explicitly defined we use the its `__doc__` value
2. allow `graphene.Enum.from_enum` to get `description` and `deprecation_reason` lambdas to allow us to define a GraphQL output for a python enum without needing to change the actual enum and add a description property there:
```
    def custom_description(value):
        if not value:
            return "StarWars Episodes"

        return 'New Hope Episode' if value == Episode.NEWHOPE else 'Other'

    PyEpisode = PyEnum('PyEpisode', 'NEWHOPE,EMPIRE,JEDI')
    Episode = Enum.from_enum(PyEpisode, description=custom_description)
```