### PR TITLE
Pin graphql-core to <2.0 for Graphene 1.4

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ skipsdist = true
 [testenv]
 deps=
     pytest>=2.7.2
-    graphql-core>=1.1
+    graphql-core>=1.1,<2.0
     promise>=2.0
     graphql-relay>=0.4.5
     six


### PR DESCRIPTION
Otherwise graphql-core 2.0 will be installed witch seems incompatible to graphene 1.4.