### PR TITLE
Set all fields on input object types

### DIFF
--- a/graphene/types/inputobjecttype.py
+++ b/graphene/types/inputobjecttype.py
@@ -1,10 +1,7 @@
 from collections import OrderedDict
 
 from .base import BaseOptions, BaseType
-from .field import Field
 from .inputfield import InputField
-from .objecttype import ObjectType
-from .scalars import Scalar
 from .structures import List, NonNull
 from .unmountedtype import UnmountedType
 from .utils import yank_fields_from_attrs
@@ -50,6 +47,7 @@ class InputObjectTypeContainer(dict, BaseType):
             return field_or_type._meta.container(value)
         else:
             return value
+
 
 class InputObjectType(UnmountedType, BaseType):
     '''

--- a/graphene/types/inputobjecttype.py
+++ b/graphene/types/inputobjecttype.py
@@ -23,8 +23,8 @@ class InputObjectTypeContainer(dict, BaseType):
 
     def __init__(self, *args, **kwargs):
         dict.__init__(self, *args, **kwargs)
-        for key, value in self.items():
-            setattr(self, key, value)
+        for key in self._meta.fields.keys():
+            setattr(self, key, self.get(key, None))
 
     def __init_subclass__(cls, *args, **kwargs):
         pass


### PR DESCRIPTION
Previously, this only set fields that were explicitly provided in the query.  Optional input fields that were _not_ provided in the query were left as Graphene field definition types (such as `List` or `ID`).