### PR TITLE
Relay documentation reflects api changes in 2.0

### DIFF
--- a/docs/relay/nodes.rst
+++ b/docs/relay/nodes.rst
@@ -75,10 +75,10 @@ Accessing node types
 --------------------
 
 If we want to retrieve node instances from a ``global_id`` (scalar that identifies an instance by it's type name and id),
-we can simply do ``Node.get_node_from_global_id(global_id, context, info)``.
+we can simply do ``Node.get_node_from_global_id(info, global_id)``.
 
 In the case we want to restrict the instance retrieval to a specific type, we can do:
-``Node.get_node_from_global_id(global_id, context, info, only_type=Ship)``. This will raise an error
+``Node.get_node_from_global_id(info, global_id, only_type=Ship)``. This will raise an error
 if the ``global_id`` doesn't correspond to a Ship type.
 
 


### PR DESCRIPTION
Specifically, get_node_from_global_id.