### PR TITLE
Use more Pythonic terminology here

### DIFF
--- a/docs/execution/middleware.rst
+++ b/docs/execution/middleware.rst
@@ -19,7 +19,7 @@ Middlewares ``resolve`` is invoked with several arguments:
 - ``next`` represents the execution chain. Call ``next`` to continue evalution.
 - ``root`` is the root value object passed throughout the query.
 - ``info`` is the resolver info.
-- ``args`` is the hash of arguments passed to the field.
+- ``args`` is the dict of arguments passed to the field.
 
 Example
 -------


### PR DESCRIPTION
"Hash" in the Python world implies a cryptographic hash, or possibly a checksum. Here, I believe "hash" is being used to mean "hash map", which would be more commonly known in Python as a dictionary, or dict for short.