### PR TITLE
Allow user to specify mutation description

### DIFF
--- a/graphene/types/mutation.py
+++ b/graphene/types/mutation.py
@@ -77,5 +77,5 @@ class Mutation(ObjectType):
     @classmethod
     def Field(cls, *args, **kwargs):
         return Field(
-            cls._meta.output, args=cls._meta.arguments, resolver=cls._meta.resolver
+            cls._meta.output, args=cls._meta.arguments, resolver=cls._meta.resolver, description=cls.__doc__
         )


### PR DESCRIPTION
At the moment user is unable to specify mutation description. 

```python
class AddProduct(relay.ClientIdMutation):
     """ Some description """ # ← this discription is assigned to mutation payload instead of mutation type itself
    class Meta:
        description = ""  # ←same as above
    # ...

class Mutation(graphene.ObjectType):
    add_product = AddProduct.Field(description="Test") # ← this is ignored
```

We can change this behaviour so mutation class documentation will be automatically reflected in GraphQL schema (type description).

Example:

```python
class AddProduct(relay.ClientIdMutation):
    """Mutation description""" # ←this becomes mutation description
    class Meta:
        description = "Payload description"  # ←this becomes mutation payload description
    # ...

class Mutation(graphene.ObjectType):
    add_product = AddProduct.Field()
    # ...
```

will be equivalent to following GraphQL SDL:
```graphql
type Mutation {
  # Mutation description
  addProduct(input: AddProductInput!): AddProductPayload
}

type AddProductPayload {
  # Payload description
  product: Product
}
```

As a result user will see type description in tools like GraphiQL which are using GraphQL introspection.