### PR TITLE
Raise better error if type is missing from schema

### DIFF
--- a/graphene/types/typemap.py
+++ b/graphene/types/typemap.py
@@ -46,7 +46,10 @@ def resolve_type(resolve_type_func, map, type_name, root, info):
 
     if inspect.isclass(_type) and issubclass(_type, ObjectType):
         graphql_type = map.get(_type._meta.name)
-        assert graphql_type and graphql_type.graphene_type == _type, (
+        assert graphql_type, "Can't find type {} in schema".format(
+            _type._meta.name
+        )
+        assert graphql_type.graphene_type == _type, (
             'The type {} does not match with the associated graphene type {}.'
         ).format(_type, graphql_type.graphene_type)
         return graphql_type


### PR DESCRIPTION
Current it errors with `AttributeError: 'NoneType' object has no attribute 'graphene_type'` if the type is not in the typemap. This PR improves that error.