### PR TITLE
Dict or attr default resolver

### DIFF
--- a/graphene/types/resolver.py
+++ b/graphene/types/resolver.py
@@ -7,9 +7,10 @@ def dict_resolver(attname, default_value, root, info, **args):
 
 
 def dict_or_attr_resolver(attname, default_value, root, info, **args):
+    resolver = attr_resolver
     if isinstance(root, dict):
-        return dict_resolver(attname, default_value, root, info, **args)
-    return attr_resolver(attname, default_value, root, info, **args)
+        resolver = dict_resolver
+    return resolver(attname, default_value, root, info, **args)
 
 
 default_resolver = dict_or_attr_resolver

--- a/graphene/types/resolver.py
+++ b/graphene/types/resolver.py
@@ -6,7 +6,13 @@ def dict_resolver(attname, default_value, root, info, **args):
     return root.get(attname, default_value)
 
 
-default_resolver = attr_resolver
+def dict_or_attr_resolver(attname, default_value, root, info, **args):
+    if isinstance(root, dict):
+        return dict_resolver(attname, default_value, root, info, **args)
+    return attr_resolver(attname, default_value, root, info, **args)
+
+
+default_resolver = dict_or_attr_resolver
 
 
 def set_default_resolver(resolver):

--- a/graphene/types/tests/test_resolver.py
+++ b/graphene/types/tests/test_resolver.py
@@ -39,11 +39,11 @@ def test_dict_resolver_default_value():
 
 
 def test_dict_or_attr_resolver():
-    resolved = dict_or_attr_resolver('attr', None, demo_dict, info, **args)
-    assert resolved == 'value'
+    resolved = dict_or_attr_resolver("attr", None, demo_dict, info, **args)
+    assert resolved == "value"
 
-    resolved = dict_or_attr_resolver('attr', None, demo_obj, info, **args)
-    assert resolved == 'value'
+    resolved = dict_or_attr_resolver("attr", None, demo_obj, info, **args)
+    assert resolved == "value"
 
 
 def test_get_default_resolver_is_attr_resolver():

--- a/graphene/types/tests/test_resolver.py
+++ b/graphene/types/tests/test_resolver.py
@@ -2,6 +2,7 @@
 from ..resolver import (
     attr_resolver,
     dict_resolver,
+    dict_or_attr_resolver,
     get_default_resolver,
     set_default_resolver,
 )
@@ -37,8 +38,16 @@ def test_dict_resolver_default_value():
     assert resolved == "default"
 
 
+def test_dict_or_attr_resolver():
+    resolved = dict_or_attr_resolver('attr', None, demo_dict, info, **args)
+    assert resolved == 'value'
+
+    resolved = dict_or_attr_resolver('attr', None, demo_obj, info, **args)
+    assert resolved == 'value'
+
+
 def test_get_default_resolver_is_attr_resolver():
-    assert get_default_resolver() == attr_resolver
+    assert get_default_resolver() == dict_or_attr_resolver
 
 
 def test_set_default_resolver_workd():


### PR DESCRIPTION
I've created a `dict_or_attr_resolver` so that you can pass dicts or objects to object types.

I've also set it as the default resolver since I can't think of a downside but let me know if you don't think thats a good idea.