### PR TITLE
Changed dead links to Relay documentation

### DIFF
--- a/docs/relay/index.rst
+++ b/docs/relay/index.rst
@@ -21,9 +21,9 @@ Useful links
 -  `Relay Cursor Connection Specification`_
 -  `Relay input Object Mutation`_
 
-.. _Relay: https://facebook.github.io/relay/docs/graphql-relay-specification.html
+.. _Relay: https://facebook.github.io/relay/docs/en/graphql-in-relay.html
 .. _Relay specification: https://facebook.github.io/relay/graphql/objectidentification.htm#sec-Node-root-field
-.. _Getting started with Relay: https://facebook.github.io/relay/docs/graphql-relay-specification.html
+.. _Getting started with Relay: https://facebook.github.io/relay/docs/en/graphql-in-relay.html
 .. _Relay Global Identification Specification: https://facebook.github.io/relay/graphql/objectidentification.htm
 .. _Relay Cursor Connection Specification: https://facebook.github.io/relay/graphql/connections.htm
 .. _Relay input Object Mutation: https://facebook.github.io/relay/graphql/mutations.htm


### PR DESCRIPTION
https://facebook.github.io/relay/docs/graphql-relay-specification.html is no longer available,
https://facebook.github.io/relay/docs/en/graphql-in-relay.html seems to be the current version