### PR TITLE
Use input_class as arguments if dict

### DIFF
--- a/graphene/types/mutation.py
+++ b/graphene/types/mutation.py
@@ -54,7 +54,10 @@ class Mutation(ObjectType):
                     ).format(name=cls.__name__))
 
             if input_class:
-                arguments = props(input_class)
+                if isinstance(input_class, dict):
+                    arguments = input_class
+                else:
+                    arguments = props(input_class)
             else:
                 arguments = {}
 


### PR DESCRIPTION
For two of my GraphQL mutations, I want to have my create and update functions use the same input parameters, but update with an additional "id" field. I strongly believe in "don't repeat yourself", so I would like to create one dict or class that they can both use/inherit, and be able to add the "id" to the update function. If I decide to add new parameters, I want both mutations to be affected with minimal code updates.

I tried a few things, but none worked. After looking at the code, I saw that there was a simple fix that would allow me to use a dictionary and be able to do this:
```python
UserParameters = {
    "name": graphene.String(),
    "email": graphene.String(),
    ...
}

class UserCreate(graphene.Mutation):
    Arguments = {
        **UserParameters,
        "password": graphene.String()
    }
   ...

class UserUpdate(graphene.Mutation):
    Arguments = {
        **UserParameters,
        "id": graphene.ID(required=True)
    }
    ...
```

I don't know if there was another way to achieve this result with the current method of creating the argument inputs.
If anyone has a more Pythonic or elegant way to achieve this result, I'm open to ideas.