### PR TITLE
Update middleware example to support introspection

### DIFF
--- a/docs/execution/middleware.rst
+++ b/docs/execution/middleware.rst
@@ -57,7 +57,7 @@ logs the time it takes to resolve each field
         return_value = next(root, info, **args)
         duration = timer() - start
         logger.debug("{parent_type}.{field_name}: {duration} ms".format(
-            parent_type=root._meta.name if root else '',
+            parent_type=root._meta.name if root and hasattr(root, '_meta') else '',
             field_name=info.field_name,
             duration=round(duration * 1000, 2)
         ))


### PR DESCRIPTION
In the `timing_middleware` example, introspection queries will fail due to `Schema` and others not having `_meta` attributes. API will work and tests pass but introspection will fail, which can be quite confusing to the developer. Simple update makes sure the `root` variable has a `_meta` attribute before accessing it.