### PR TITLE
Fix broken GitHub link tags: 2.0 -> v2.0.0

### DIFF
--- a/UPGRADE-v2.0.md
+++ b/UPGRADE-v2.0.md
@@ -21,7 +21,7 @@ developer has to write to use them.
 
 
 > The type metaclasses are now deleted as they are no longer necessary.  If your code was depending
-> on this strategy for creating custom attrs, see an [example on how to do it in 2.0](https://github.com/graphql-python/graphene/blob/2.0/graphene/tests/issues/test_425.py).
+> on this strategy for creating custom attrs, see an [example on how to do it in 2.0](https://github.com/graphql-python/graphene/blob/v2.0.0/graphene/tests/issues/test_425.py).
 
 ## Deprecations
 

--- a/graphene/relay/connection.py
+++ b/graphene/relay/connection.py
@@ -102,7 +102,7 @@ class IterableConnectionField(Field):
         if is_node(type):
             raise Exception(
                 "ConnectionField's now need a explicit ConnectionType for Nodes.\n"
-                "Read more: https://github.com/graphql-python/graphene/blob/2.0/UPGRADE-v2.0.md#node-connections"
+                "Read more: https://github.com/graphql-python/graphene/blob/v2.0.0/UPGRADE-v2.0.md#node-connections"
             )
 
         assert issubclass(connection_type, Connection), (

--- a/graphene/types/abstracttype.py
+++ b/graphene/types/abstracttype.py
@@ -7,6 +7,6 @@ class AbstractType(SubclassWithMeta):
     def __init_subclass__(cls, *args, **kwargs):
         warn_deprecation(
             "Abstract type is deprecated, please use normal object inheritance instead.\n"
-            "See more: https://github.com/graphql-python/graphene/blob/2.0/UPGRADE-v2.0.md#deprecations"
+            "See more: https://github.com/graphql-python/graphene/blob/v2.0.0/UPGRADE-v2.0.md#deprecations"
         )
         super(AbstractType, cls).__init_subclass__(*args, **kwargs)

--- a/graphene/types/mutation.py
+++ b/graphene/types/mutation.py
@@ -50,7 +50,8 @@ class Mutation(ObjectType):
                     warn_deprecation((
                         "Please use {name}.Arguments instead of {name}.Input."
                         "Input is now only used in ClientMutationID.\n"
-                        "Read more: https://github.com/graphql-python/graphene/blob/v2.0.0/UPGRADE-v2.0.md#mutation-input"
+                        "Read more:"
+                        " https://github.com/graphql-python/graphene/blob/v2.0.0/UPGRADE-v2.0.md#mutation-input"
                     ).format(name=cls.__name__))
 
             if input_class:

--- a/graphene/types/mutation.py
+++ b/graphene/types/mutation.py
@@ -50,7 +50,7 @@ class Mutation(ObjectType):
                     warn_deprecation((
                         "Please use {name}.Arguments instead of {name}.Input."
                         "Input is now only used in ClientMutationID.\n"
-                        "Read more: https://github.com/graphql-python/graphene/blob/2.0/UPGRADE-v2.0.md#mutation-input"
+                        "Read more: https://github.com/graphql-python/graphene/blob/v2.0.0/UPGRADE-v2.0.md#mutation-input"
                     ).format(name=cls.__name__))
 
             if input_class:


### PR DESCRIPTION
Various bits of the code links to GitHub files at `2.0`, which is broken (404 Not Found).

This updates the broken links to `v2.0.0`, which works. (I'm guessing that's the intended target.)