### PR TITLE
Update .gitignore for pytest 3.4+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ htmlcov/
 .coverage
 .coverage.*
 .cache
+.pytest_cache
 nosetests.xml
 coverage.xml
 *,cover


### PR DESCRIPTION
Pytest 3.4.0 changes the default cache directory from `.cache` to `.pytest_cache`.

Changelog: https://docs.pytest.org/en/latest/changelog.html#pytest-3-4-0-2018-01-30