### PR TITLE
Fix bug when setting a Relay ConnectionField to be required

### DIFF
--- a/graphene/relay/connection.py
+++ b/graphene/relay/connection.py
@@ -115,9 +115,6 @@ class IterableConnectionField(Field):
 
     @classmethod
     def resolve_connection(cls, connection_type, args, resolved):
-        if isinstance(connection_type, NonNull):
-            connection_type = connection_type.of_type
-
         if isinstance(resolved, connection_type):
             return resolved
 
@@ -138,6 +135,9 @@ class IterableConnectionField(Field):
     @classmethod
     def connection_resolver(cls, resolver, connection_type, root, info, **args):
         resolved = resolver(root, info, **args)
+
+        if isinstance(connection_type, NonNull):
+            connection_type = connection_type.of_type
 
         on_resolve = partial(cls.resolve_connection, connection_type, args)
         if is_thenable(resolved):

--- a/graphene/relay/connection.py
+++ b/graphene/relay/connection.py
@@ -99,7 +99,10 @@ class IterableConnectionField(Field):
     def type(self):
         type = super(IterableConnectionField, self).type
         connection_type = type
-        if is_node(type):
+        if isinstance(type, NonNull):
+            connection_type = type.of_type
+
+        if is_node(connection_type):
             raise Exception(
                 "ConnectionField's now need a explicit ConnectionType for Nodes.\n"
                 "Read more: https://github.com/graphql-python/graphene/blob/v2.0.0/UPGRADE-v2.0.md#node-connections"
@@ -108,10 +111,13 @@ class IterableConnectionField(Field):
         assert issubclass(connection_type, Connection), (
             '{} type have to be a subclass of Connection. Received "{}".'
         ).format(self.__class__.__name__, connection_type)
-        return connection_type
+        return type
 
     @classmethod
     def resolve_connection(cls, connection_type, args, resolved):
+        if isinstance(connection_type, NonNull):
+            connection_type = connection_type.of_type
+
         if isinstance(resolved, connection_type):
             return resolved
 

--- a/graphene/relay/tests/test_connection.py
+++ b/graphene/relay/tests/test_connection.py
@@ -1,6 +1,6 @@
 import pytest
 
-from ...types import Argument, Field, Int, List, NonNull, ObjectType, String
+from ...types import Argument, Field, Int, List, NonNull, ObjectType, String, Schema
 from ..connection import Connection, ConnectionField, PageInfo
 from ..node import Node
 
@@ -155,3 +155,23 @@ def test_connectionfield_custom_args():
         'last': Argument(Int),
         'extra': Argument(String),
     }
+
+
+def test_connectionfield_required():
+    class MyObjectConnection(Connection):
+
+        class Meta:
+            node = MyObject
+
+    class Query(ObjectType):
+        test_connection = ConnectionField(MyObjectConnection, required=True)
+
+        def resolve_test_connection(root, info, **args):
+            return []
+
+    schema = Schema(query=Query)
+    executed = schema.execute(
+        '{ testConnection { edges { cursor } } }'
+    )
+    assert not executed.errors
+    assert executed.data == {'testConnection': {'edges': []}}


### PR DESCRIPTION
Came across this when setting up Relay Connections in my schema. Worked around it by subclassing ConnectionField but thought I'd contribute the fix upstream.