### PR TITLE
Remove unused field

### DIFF
--- a/graphene/relay/connection.py
+++ b/graphene/relay/connection.py
@@ -129,7 +129,6 @@ class IterableConnectionField(Field):
             edge_type=connection_type.Edge,
             pageinfo_type=PageInfo
         )
-        connection.iterable = resolved
         return connection
 
     @classmethod


### PR DESCRIPTION
Issue: #684 

`.iterable` is not used anywhere in the code so can be safely removed.



