### PR TITLE
add Graphene-Mongo to intergrations index of docs/index.rst

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -18,3 +18,4 @@ Integrations
 * `Graphene-Django <http://docs.graphene-python.org/projects/django/en/latest/>`_ (`source <https://github.com/graphql-python/graphene-django/>`_)
 * `Graphene-SQLAlchemy <http://docs.graphene-python.org/projects/sqlalchemy/en/latest/>`_ (`source <https://github.com/graphql-python/graphene-sqlalchemy/>`_)
 * `Graphene-GAE <http://docs.graphene-python.org/projects/gae/en/latest/>`_ (`source <https://github.com/graphql-python/graphene-gae/>`_)
+* `Graphene-Mongo <http://graphene-mongo.readthedocs.io/en/latest/>`_ (`source <https://github.com/graphql-python/graphene-mongo>`_)


### PR DESCRIPTION
The Graphene-Mongo integration is missing from the intergration index. So I added the Graphene-Mongo docs to the integration index.

[Graphene-Mongo repo](https://github.com/graphql-python/graphene-mongo)
[Graphene-Mongo docs](http://graphene-mongo.readthedocs.io/en/latest/)

Thank you for your efforts.