### PR TITLE
Add isort precommit hook & run on all files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,4 +11,3 @@ trim_trailing_whitespace = true
 [*.{py,rst,ini}]
 indent_style = space
 indent_size = 4
-

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,2 @@
+[settings]
+known_third_party = aniso8601,graphql,graphql_relay,promise,pytest,pytz,pyutils,setuptools,six,snapshottest,sphinx_graphene_theme

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,6 @@
+repos:
 -   repo: git://github.com/pre-commit/pre-commit-hooks
-    sha: v0.8.0
+    rev: v1.2.3
     hooks:
     -   id: autopep8-wrapper
         args:
@@ -15,3 +16,11 @@
     -   id: pretty-format-json
         args:
         - --autofix
+-   repo: https://github.com/asottile/seed-isort-config
+    rev: v1.0.0
+    hooks:
+    -   id: seed-isort-config
+-   repo: https://github.com/pre-commit/mirrors-isort
+    rev: v4.3.4
+    hooks:
+    -   id: isort

--- a/UPGRADE-v2.0.md
+++ b/UPGRADE-v2.0.md
@@ -207,7 +207,7 @@ Before:
 ```python
 class SomeMutation(Mutation):
     ...
-    
+
     @classmethod
     def mutate(cls, instance, args, context, info):
         ...
@@ -218,7 +218,7 @@ With 2.0:
 ```python
 class SomeMutation(Mutation):
     ...
-    
+
     def mutate(self, info, **args):
         ...
 ```
@@ -231,7 +231,7 @@ class SomeMutation(Mutation):
         first_name = String(required=True)
         last_name = String(required=True)
     ...
-    
+
     def mutate(self, info, first_name, last_name):
         ...
 ```
@@ -250,7 +250,7 @@ If you are using Middelwares, you need to some adjustments:
 Before:
 
 ```python
-class MyGrapheneMiddleware(object):    
+class MyGrapheneMiddleware(object):  
     def resolve(self, next_mw, root, args, context, info):
 
         ## Middleware code
@@ -261,7 +261,7 @@ class MyGrapheneMiddleware(object):
 With 2.0:
 
 ```python
-class MyGrapheneMiddleware(object):    
+class MyGrapheneMiddleware(object):  
     def resolve(self, next_mw, root, info, **args):
         context = info.context
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,13 @@
 import os
 
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+# html_theme = 'alabaster'
+# if on_rtd:
+#     html_theme = 'sphinx_rtd_theme'
+import sphinx_graphene_theme
+
 on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 
 # -*- coding: utf-8 -*-
@@ -130,13 +138,6 @@ todo_include_todos = True
 
 # -- Options for HTML output ----------------------------------------------
 
-# The theme to use for HTML and HTML Help pages.  See the documentation for
-# a list of builtin themes.
-#
-# html_theme = 'alabaster'
-# if on_rtd:
-#     html_theme = 'sphinx_rtd_theme'
-import sphinx_graphene_theme
 
 html_theme = "sphinx_graphene_theme"
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,11 +1,4 @@
 import os
-
-# The theme to use for HTML and HTML Help pages.  See the documentation for
-# a list of builtin themes.
-#
-# html_theme = 'alabaster'
-# if on_rtd:
-#     html_theme = 'sphinx_rtd_theme'
 import sphinx_graphene_theme
 
 on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
@@ -138,6 +131,12 @@ todo_include_todos = True
 
 # -- Options for HTML output ----------------------------------------------
 
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+# html_theme = 'alabaster'
+# if on_rtd:
+#     html_theme = 'sphinx_rtd_theme'
 
 html_theme = "sphinx_graphene_theme"
 

--- a/docs/execution/dataloader.rst
+++ b/docs/execution/dataloader.rst
@@ -88,7 +88,7 @@ Naively, if ``me``, ``bestFriend`` and ``friends`` each need to request the back
 there could be at most 13 database requests!
 
 
-When using DataLoader, we could define the User type using our previous example with 
+When using DataLoader, we could define the User type using our previous example with
 leaner code and at most 4 database requests, and possibly fewer if there are cache hits.
 
 

--- a/docs/relay/mutations.rst
+++ b/docs/relay/mutations.rst
@@ -41,7 +41,7 @@ Mutations can also accept files, that's how it will work with different integrat
          class Input:
              pass
              # nothing needed for uploading file
-     
+
          # your return fields
          success = graphene.String()
 

--- a/docs/testing/index.rst
+++ b/docs/testing/index.rst
@@ -101,7 +101,7 @@ Here is a simple example on how our tests will look if we use ``pytest``:
 If we are using ``unittest``:
 
 .. code:: python
-    
+
     from snapshottest import TestCase
 
     class APITestCase(TestCase):

--- a/examples/starwars/tests/snapshots/snap_test_query.py
+++ b/examples/starwars/tests/snapshots/snap_test_query.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals
 
 from snapshottest import Snapshot
 
-
 snapshots = Snapshot()
 
 snapshots['test_hero_name_query 1'] = {

--- a/examples/starwars_relay/tests/snapshots/snap_test_connections.py
+++ b/examples/starwars_relay/tests/snapshots/snap_test_connections.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals
 
 from snapshottest import Snapshot
 
-
 snapshots = Snapshot()
 
 snapshots['test_correct_fetch_first_ship_rebels 1'] = {

--- a/examples/starwars_relay/tests/snapshots/snap_test_mutation.py
+++ b/examples/starwars_relay/tests/snapshots/snap_test_mutation.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals
 
 from snapshottest import Snapshot
 
-
 snapshots = Snapshot()
 
 snapshots['test_mutations 1'] = {

--- a/examples/starwars_relay/tests/snapshots/snap_test_objectidentification.py
+++ b/examples/starwars_relay/tests/snapshots/snap_test_objectidentification.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals
 
 from snapshottest import Snapshot
 
-
 snapshots = Snapshot()
 
 snapshots['test_correctly_fetches_id_name_rebels 1'] = {

--- a/graphene/pyutils/compat.py
+++ b/graphene/pyutils/compat.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+
 import six
 
 try:

--- a/graphene/pyutils/signature.py
+++ b/graphene/pyutils/signature.py
@@ -4,11 +4,11 @@ Back port of Python 3.3's function signature tools from the inspect module,
 modified to be compatible with Python 2.7 and 3.2+.
 """
 from __future__ import absolute_import, division, print_function
-import itertools
+
 import functools
+import itertools
 import re
 import types
-
 from collections import OrderedDict
 
 __version__ = "0.4"

--- a/graphene/relay/tests/test_connection.py
+++ b/graphene/relay/tests/test_connection.py
@@ -1,6 +1,7 @@
 import pytest
 
-from ...types import Argument, Field, Int, List, NonNull, ObjectType, String, Schema
+from ...types import (Argument, Field, Int, List, NonNull, ObjectType, Schema,
+                      String)
 from ..connection import Connection, ConnectionField, PageInfo
 from ..node import Node
 

--- a/graphene/relay/tests/test_mutation.py
+++ b/graphene/relay/tests/test_mutation.py
@@ -1,5 +1,4 @@
 import pytest
-
 from promise import Promise
 
 from ...types import (ID, Argument, Field, InputField, InputObjectType,

--- a/graphene/tests/issues/test_425.py
+++ b/graphene/tests/issues/test_425.py
@@ -1,9 +1,10 @@
 # https://github.com/graphql-python/graphene/issues/425
 # Adapted for Graphene 2.0
 
-from graphene.types.objecttype import ObjectType, ObjectTypeOptions
-from graphene.types.inputobjecttype import InputObjectType, InputObjectTypeOptions
 from graphene.types.enum import Enum, EnumOptions
+from graphene.types.inputobjecttype import (InputObjectType,
+                                            InputObjectTypeOptions)
+from graphene.types.objecttype import ObjectType, ObjectTypeOptions
 
 
 # ObjectType

--- a/graphene/types/abstracttype.py
+++ b/graphene/types/abstracttype.py
@@ -1,5 +1,5 @@
-from ..utils.subclass_with_meta import SubclassWithMeta
 from ..utils.deprecated import warn_deprecation
+from ..utils.subclass_with_meta import SubclassWithMeta
 
 
 class AbstractType(SubclassWithMeta):

--- a/graphene/types/datetime.py
+++ b/graphene/types/datetime.py
@@ -2,8 +2,8 @@ from __future__ import absolute_import
 
 import datetime
 
+from aniso8601 import parse_date, parse_datetime, parse_time
 from graphql.language import ast
-from aniso8601 import parse_datetime, parse_date, parse_time
 
 from .scalars import Scalar
 

--- a/graphene/types/enum.py
+++ b/graphene/types/enum.py
@@ -4,10 +4,9 @@ import six
 
 from graphene.utils.subclass_with_meta import SubclassWithMeta_Meta
 
+from ..pyutils.compat import Enum as PyEnum
 from .base import BaseOptions, BaseType
 from .unmountedtype import UnmountedType
-
-from ..pyutils.compat import Enum as PyEnum
 
 
 def eq_enum(self, other):

--- a/graphene/types/generic.py
+++ b/graphene/types/generic.py
@@ -1,8 +1,9 @@
 from __future__ import unicode_literals
 
-from graphene.types.scalars import MAX_INT, MIN_INT
 from graphql.language.ast import (BooleanValue, FloatValue, IntValue,
                                   ListValue, ObjectValue, StringValue)
+
+from graphene.types.scalars import MAX_INT, MIN_INT
 
 from .scalars import Scalar
 

--- a/graphene/types/mutation.py
+++ b/graphene/types/mutation.py
@@ -1,12 +1,11 @@
 from collections import OrderedDict
 
+from ..utils.deprecated import warn_deprecation
 from ..utils.get_unbound_function import get_unbound_function
 from ..utils.props import props
 from .field import Field
 from .objecttype import ObjectType, ObjectTypeOptions
 from .utils import yank_fields_from_attrs
-from ..utils.deprecated import warn_deprecation
-
 
 # For static type checking with Mypy
 MYPY = False

--- a/graphene/types/scalars.py
+++ b/graphene/types/scalars.py
@@ -1,5 +1,4 @@
 import six
-
 from graphql.language.ast import (BooleanValue, FloatValue, IntValue,
                                   StringValue)
 

--- a/graphene/types/schema.py
+++ b/graphene/types/schema.py
@@ -1,6 +1,6 @@
 import inspect
 
-from graphql import GraphQLSchema, graphql, is_type, GraphQLObjectType
+from graphql import GraphQLObjectType, GraphQLSchema, graphql, is_type
 from graphql.type.directives import (GraphQLDirective, GraphQLIncludeDirective,
                                      GraphQLSkipDirective)
 from graphql.type.introspection import IntrospectionSchema

--- a/graphene/types/tests/test_abstracttype.py
+++ b/graphene/types/tests/test_abstracttype.py
@@ -1,10 +1,10 @@
 import pytest
 
+from .. import abstracttype
+from ..abstracttype import AbstractType
+from ..field import Field
 from ..objecttype import ObjectType
 from ..unmountedtype import UnmountedType
-from ..abstracttype import AbstractType
-from .. import abstracttype
-from ..field import Field
 
 
 class MyType(ObjectType):

--- a/graphene/types/tests/test_base.py
+++ b/graphene/types/tests/test_base.py
@@ -1,6 +1,6 @@
 import pytest
 
-from ..base import BaseType, BaseOptions
+from ..base import BaseOptions, BaseType
 
 
 class CustomOptions(BaseOptions):

--- a/graphene/types/tests/test_datetime.py
+++ b/graphene/types/tests/test_datetime.py
@@ -1,10 +1,9 @@
 import datetime
 
 import pytz
-
 from graphql import GraphQLError
 
-from ..datetime import DateTime, Date, Time
+from ..datetime import Date, DateTime, Time
 from ..objecttype import ObjectType
 from ..schema import Schema
 

--- a/graphene/types/tests/test_dynamic.py
+++ b/graphene/types/tests/test_dynamic.py
@@ -1,4 +1,5 @@
 from functools import partial
+
 from ..dynamic import Dynamic
 from ..scalars import String
 from ..structures import List, NonNull

--- a/graphene/types/tests/test_enum.py
+++ b/graphene/types/tests/test_enum.py
@@ -1,10 +1,10 @@
 import six
 
-from ..schema import Schema, ObjectType
 from ..argument import Argument
 from ..enum import Enum, PyEnum
 from ..field import Field
 from ..inputfield import InputField
+from ..schema import ObjectType, Schema
 
 
 def test_enum_construction():

--- a/graphene/types/tests/test_inputobjecttype.py
+++ b/graphene/types/tests/test_inputobjecttype.py
@@ -4,9 +4,9 @@ from ..field import Field
 from ..inputfield import InputField
 from ..inputobjecttype import InputObjectType
 from ..objecttype import ObjectType
-from ..unmountedtype import UnmountedType
-from ..scalars import String, Boolean
+from ..scalars import Boolean, String
 from ..schema import Schema
+from ..unmountedtype import UnmountedType
 
 
 class MyType(object):

--- a/graphene/types/tests/test_objecttype.py
+++ b/graphene/types/tests/test_objecttype.py
@@ -3,10 +3,10 @@ import pytest
 from ..field import Field
 from ..interface import Interface
 from ..objecttype import ObjectType
-from ..unmountedtype import UnmountedType
-from ..structures import NonNull
 from ..scalars import String
 from ..schema import Schema
+from ..structures import NonNull
+from ..unmountedtype import UnmountedType
 
 
 class MyType(Interface):

--- a/graphene/types/tests/test_query.py
+++ b/graphene/types/tests/test_query.py
@@ -1,19 +1,19 @@
 import json
 from functools import partial
 
-from graphql import GraphQLError, Source, execute, parse, ResolveInfo
+from graphql import GraphQLError, ResolveInfo, Source, execute, parse
 
+from ..context import Context
 from ..dynamic import Dynamic
 from ..field import Field
 from ..inputfield import InputField
 from ..inputobjecttype import InputObjectType
 from ..interface import Interface
 from ..objecttype import ObjectType
-from ..scalars import Int, String, Boolean
+from ..scalars import Boolean, Int, String
 from ..schema import Schema
 from ..structures import List, NonNull
 from ..union import Union
-from ..context import Context
 
 
 def test_query():

--- a/graphene/types/tests/test_typemap.py
+++ b/graphene/types/tests/test_typemap.py
@@ -1,11 +1,9 @@
 import pytest
-
 from graphql.type import (GraphQLArgument, GraphQLEnumType, GraphQLEnumValue,
                           GraphQLField, GraphQLInputObjectField,
                           GraphQLInputObjectType, GraphQLInterfaceType,
                           GraphQLObjectType, GraphQLString)
 
-from ..structures import List, NonNull
 from ..dynamic import Dynamic
 from ..enum import Enum
 from ..field import Field
@@ -13,7 +11,8 @@ from ..inputfield import InputField
 from ..inputobjecttype import InputObjectType
 from ..interface import Interface
 from ..objecttype import ObjectType
-from ..scalars import String, Int
+from ..scalars import Int, String
+from ..structures import List, NonNull
 from ..typemap import TypeMap, resolve_type
 
 

--- a/graphene/types/tests/test_uuid.py
+++ b/graphene/types/tests/test_uuid.py
@@ -1,6 +1,6 @@
-from ..uuid import UUID
 from ..objecttype import ObjectType
 from ..schema import Schema
+from ..uuid import UUID
 
 
 class Query(ObjectType):

--- a/graphene/types/union.py
+++ b/graphene/types/union.py
@@ -1,7 +1,6 @@
 from .base import BaseOptions, BaseType
 from .unmountedtype import UnmountedType
 
-
 # For static type checking with Mypy
 MYPY = False
 if MYPY:

--- a/graphene/utils/annotate.py
+++ b/graphene/utils/annotate.py
@@ -1,6 +1,6 @@
 import six
-from ..pyutils.compat import signature, func_name
 
+from ..pyutils.compat import func_name, signature
 from .deprecated import warn_deprecation
 
 

--- a/graphene/utils/resolve_only_args.py
+++ b/graphene/utils/resolve_only_args.py
@@ -1,4 +1,5 @@
 from functools import wraps
+
 from .deprecated import deprecated
 
 

--- a/graphene/utils/subclass_with_meta.py
+++ b/graphene/utils/subclass_with_meta.py
@@ -1,5 +1,6 @@
-import six
 from inspect import isclass
+
+import six
 
 from ..pyutils.init_subclass import InitSubclassMeta
 from .props import props

--- a/graphene/utils/tests/test_annotate.py
+++ b/graphene/utils/tests/test_annotate.py
@@ -1,4 +1,5 @@
 import pytest
+
 from ..annotate import annotate
 
 

--- a/graphene/utils/tests/test_deprecated.py
+++ b/graphene/utils/tests/test_deprecated.py
@@ -1,6 +1,8 @@
 import pytest
+
 from .. import deprecated
-from ..deprecated import deprecated as deprecated_decorator, warn_deprecation
+from ..deprecated import deprecated as deprecated_decorator
+from ..deprecated import warn_deprecation
 
 
 def test_warn_deprecation(mocker):

--- a/graphene/utils/tests/test_resolve_only_args.py
+++ b/graphene/utils/tests/test_resolve_only_args.py
@@ -1,5 +1,5 @@
-from ..resolve_only_args import resolve_only_args
 from .. import deprecated
+from ..resolve_only_args import resolve_only_args
 
 
 def test_resolve_only_args(mocker):

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,9 @@
-from setuptools import find_packages, setup
-from setuptools.command.test import test as TestCommand
-import sys
 import ast
 import re
+import sys
+
+from setuptools import find_packages, setup
+from setuptools.command.test import test as TestCommand
 
 _version_re = re.compile(r'VERSION\s+=\s+(.*)')
 


### PR DESCRIPTION
1. Add [isort](https://github.com/pre-commit/mirrors-isort) & [seed-isort-config](https://github.com/asottile/seed-isort-config) pre-commit hooks to .pre-commit-config.yaml
2. Update pre-commit hooks via `pre-commit autoupdate` (in a virtualenv)
3. `tox -e pre-commit` to run pre-commit hooks on all files

This PR is an alternative to https://github.com/graphql-python/graphene/pull/734 where the simpler reorder-python-imports pre-commit hook was added. @jkimbo and @syrusakbary prefer isort, so I'm creating this one instead. I truly don't care which import sorter is used, but I really like having one in there to avoid having to sort my own imports. :)