### PR TITLE
Update contributing docs about using tox and sync tox pytest cmd with travis

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,11 +79,16 @@ After cloning this repo, ensure dependencies are installed by running:
 pip install -e ".[test]"
 ```
 
-After developing, the full test suite can be evaluated by running:
+Well-written tests and maintaining good test coverage is important to this project. While developing, run new and existing tests with:
 
 ```sh
-py.test graphene --cov=graphene --benchmark-skip # Use -v -s for verbose mode
+py.test PATH/TO/MY/DIR/test_test.py # Single file
+py.test PATH/TO/MY/DIR/ # All tests in directory
 ```
+
+Add the `-s` flag if you have introduced breakpoints into the code for debugging.
+Add the `-v` ("verbose") flag to get more detailed test output. For even more detailed output, use `-vv`. 
+Check out the [pytest documentation](https://docs.pytest.org/en/latest/) for more options and test running controls.  
 
 You can also run the benchmarks with:
 
@@ -91,6 +96,15 @@ You can also run the benchmarks with:
 py.test graphene --benchmark-only
 ```
 
+graphene supports several versions of Python. To make sure that changes do not break compatibility with any of those versions, we use `tox` to create virtualenvs for each python version and run tests with that version. To run against all python versions defined in the `tox.ini` config file, just run: 
+```sh
+tox
+```
+If you wish to run against a specific version defined in the `tox.ini` file: 
+```sh
+tox -e py36
+```
+Tox can only use whatever versions of python are installed on your system. When you create a pull request, Travis will also be running the same tests and report the results, so there is no need for potential contributors to try to install every single version of python on their own system ahead of time. We appreciate opening issues and pull requests to make graphene even more stable & useful! 
 
 ### Documentation
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ You can also run the benchmarks with:
 py.test graphene --benchmark-only
 ```
 
-graphene supports several versions of Python. To make sure that changes do not break compatibility with any of those versions, we use `tox` to create virtualenvs for each python version and run tests with that version. To run against all python versions defined in the `tox.ini` config file, just run: 
+Graphene supports several versions of Python. To make sure that changes do not break compatibility with any of those versions, we use `tox` to create virtualenvs for each python version and run tests with that version. To run against all python versions defined in the `tox.ini` config file, just run: 
 ```sh
 tox
 ```

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,5 @@
 import os
+
 import sphinx_graphene_theme
 
 on_rtd = os.environ.get('READTHEDOCS', None) == 'True'

--- a/tox.ini
+++ b/tox.ini
@@ -3,22 +3,11 @@ envlist = flake8,py27,py33,py34,py35,py36,pre-commit,pypy
 skipsdist = true
 
 [testenv]
-deps=
-    pytest>=2.7.2
-    graphql-core>=1.1
-    promise>=2.0
-    graphql-relay>=0.4.5
-    six
-    blinker
-    singledispatch
-    mock
-    pytz
-    iso8601
-    pytest-benchmark
+deps = .[test]
 setenv =
      PYTHONPATH = .:{envdir}
 commands=
-    py.test
+    py.test --cov=graphene graphene examples
 
 [testenv:pre-commit]
 basepython=python3.6


### PR DESCRIPTION
Followup suggestion by @jkimbo over on https://github.com/graphql-python/graphene/pull/741 to:

1. Have tox pytest cmd match Travis command
2. Update README contributing info to include mention of using `tox`. 