### PR TITLE
Create Makefile with several useful dev commands, and move dev requirements into requirements-dev.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,6 @@ target/
 *.sqlite3
 .vscode
 .mypy_cache
+
+# Development virtualenv
+venv*

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ before_install:
 install:
 - |
   if [ "$TEST_TYPE" = build ]; then
-    pip install -e .[test]
+    pip install -r requirements-dev.txt
     python setup.py develop
   elif [ "$TEST_TYPE" = lint ]; then
     pip install flake8

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,28 @@
+REBUILD_FLAG =
+
+.PHONY: all
+all: venv test
+
+.PHONY: venv
+venv: .venv.touch
+	tox -e venv $(REBUILD_FLAG)
+
+.PHONY: tests test
+tests: test
+test: .venv.touch
+	tox $(REBUILD_FLAG)
+
+.venv.touch: setup.py requirements-dev.txt
+	$(eval REBUILD_FLAG := --recreate)
+	touch .venv.touch
+
+.PHONY: install-hooks
+install-hooks:
+	tox -e pre-commit -- install -f --install-hooks
+
+.PHONY: clean
+clean:
+	find . -iname '*.pyc' -delete
+	rm -rf .tox
+	rm -rf ./venv-*
+	rm -f .venv.touch

--- a/Makefile
+++ b/Makefile
@@ -4,12 +4,12 @@ REBUILD_FLAG =
 all: venv test
 
 .PHONY: venv
-venv: .venv.touch
+venv: .venv.touch install-hooks
 	tox -e venv $(REBUILD_FLAG)
 
 .PHONY: tests test
 tests: test
-test: .venv.touch
+test: .venv.touch install-hooks
 	tox $(REBUILD_FLAG)
 
 .venv.touch: setup.py requirements-dev.txt

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,5 @@
 import os
+
 import sphinx_graphene_theme
 
 on_rtd = os.environ.get('READTHEDOCS', None) == 'True'

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,12 @@
+-e .
+pytest
+pytest-benchmark
+pytest-cov
+pytest-mock
+snapshottest
+coveralls
+six
+mock
+pytz
+iso8601
+pre-commit

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,6 @@ import re
 import sys
 
 from setuptools import find_packages, setup
-from setuptools.command.test import test as TestCommand
 
 _version_re = re.compile(r'VERSION\s+=\s+(.*)')
 
@@ -22,38 +21,6 @@ except Exception:
 
 sys.path[:] = path_copy
 
-
-class PyTest(TestCommand):
-    user_options = [('pytest-args=', 'a', "Arguments to pass to py.test")]
-
-    def initialize_options(self):
-        TestCommand.initialize_options(self)
-        self.pytest_args = []
-
-    def finalize_options(self):
-        TestCommand.finalize_options(self)
-        self.test_args = []
-        self.test_suite = True
-
-    def run_tests(self):
-        # import here, cause outside the eggs aren't loaded
-        import pytest
-        errno = pytest.main(self.pytest_args)
-        sys.exit(errno)
-
-
-tests_require = [
-    'pytest',
-    'pytest-benchmark',
-    'pytest-cov',
-    'pytest-mock',
-    'snapshottest',
-    'coveralls',
-    'six',
-    'mock',
-    'pytz',
-    'iso8601',
-]
 
 setup(
     name='graphene',
@@ -79,6 +46,7 @@ setup(
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: Implementation :: PyPy',
     ],
 
@@ -93,9 +61,7 @@ setup(
         'promise>=2.1,<3',
         'aniso8601>=3,<4',
     ],
-    tests_require=tests_require,
     extras_require={
-        'test': tests_require,
         'django': [
             'graphene-django',
         ],
@@ -103,5 +69,4 @@ setup(
             'graphene-sqlalchemy',
         ]
     },
-    cmdclass={'test': PyTest},
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,20 +1,11 @@
 [tox]
-envlist = flake8,py27,py33,py34,py35,py36,pre-commit,pypy
+project = graphene
+envlist = flake8,py27,py33,py34,py35,py36,pypy,pre-commit
 skipsdist = true
 
 [testenv]
 deps=
-    pytest>=2.7.2
-    graphql-core>=1.1
-    promise>=2.0
-    graphql-relay>=0.4.5
-    six
-    blinker
-    singledispatch
-    mock
-    pytz
-    iso8601
-    pytest-benchmark
+    -rrequirements-dev.txt
 setenv =
      PYTHONPATH = .:{envdir}
 commands=
@@ -22,12 +13,15 @@ commands=
 
 [testenv:pre-commit]
 basepython=python3.6
-deps =
-    pre-commit>0.12.0
 setenv =
     LC_CTYPE=en_US.UTF-8
 commands =
     pre-commit {posargs:run --all-files}
+
+[testenv:venv]
+basepython = python3.6
+envdir = venv-{[tox]project}
+commands =
 
 [testenv:flake8]
 deps = flake8

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,8 @@ setenv =
      PYTHONPATH = .:{envdir}
 commands=
     py.test
+    pre-commit install -f --install-hooks
+    pre-commit run --all-files
 
 [testenv:pre-commit]
 basepython=python3.6


### PR DESCRIPTION
1. Create Makefile with several useful dev commands, i.e. `make test` which runs `tox`, `make venv` which creates a development virtualenv called venv-graphene, `make clean` and `make install-hooks`. 
2. move dev requirements into `requirements-dev.txt` and delete test-related code from `setup.py`
3. Update .travis.yml to set up test environment by using the new `requirements-dev.txt` file

`make test` passes on this branch. The main thing I'm unsure of is A) any other fallout from removing the 'test' target in setup.py? B) if travis will complain at all about the .travis.yml change. 

The goal is for a new contributor to the repo to have easier start up process.
They clone repo, then run `make venv`, source that virtualenv, and then go to town writing code/tests while in a virtualenv which has benefits over installing things directly to their system. 