### PR TITLE
Don't overwrite fields on InputObject - closes #720

### DIFF
--- a/graphene/tests/issues/test_720.py
+++ b/graphene/tests/issues/test_720.py
@@ -1,0 +1,44 @@
+# https://github.com/graphql-python/graphene/issues/720
+# InputObjectTypes overwrite the "fields" attribute of the provided
+# _meta object, so even if dynamic fields are provided with a standard
+# InputObjectTypeOptions, they are ignored.
+
+import graphene
+
+
+class MyInputClass(graphene.InputObjectType):
+
+    @classmethod
+    def __init_subclass_with_meta__(
+            cls, container=None, _meta=None, fields=None, **options):
+        if _meta is None:
+            _meta = graphene.types.inputobjecttype.InputObjectTypeOptions(cls)
+        _meta.fields = fields
+        super(MyInputClass, cls).__init_subclass_with_meta__(
+            container=container, _meta=_meta, **options)
+
+
+class MyInput(MyInputClass):
+
+    class Meta:
+        fields = dict(x=graphene.Field(graphene.Int))
+
+
+class Query(graphene.ObjectType):
+    myField = graphene.Field(graphene.String, input=graphene.Argument(MyInput))
+
+    def resolve_myField(parent, info, input):
+        return 'ok'
+
+
+def test_issue():
+    query_string = '''
+    query myQuery {
+      myField(input: {x: 1})
+    }
+    '''
+
+    schema = graphene.Schema(query=Query)
+    result = schema.execute(query_string)
+
+    assert not result.errors

--- a/graphene/types/inputobjecttype.py
+++ b/graphene/types/inputobjecttype.py
@@ -50,7 +50,10 @@ class InputObjectType(UnmountedType, BaseType):
                 yank_fields_from_attrs(base.__dict__, _as=InputField)
             )
 
-        _meta.fields = fields
+        if _meta.fields:
+            _meta.fields.update(fields)
+        else:
+            _meta.fields = fields
         if container is None:
             container = type(cls.__name__, (InputObjectTypeContainer, cls), {})
         _meta.container = container


### PR DESCRIPTION
As discussed in #720, the InputObjectType overwrites the fields on its `_meta` object even if fields were provided. This PR fixes it and provides a test that fails without the fix.