### PR TITLE
Add requirements-dev.txt and remove test command in setup.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ before_install:
 install:
 - |
   if [ "$TEST_TYPE" = build ]; then
-    pip install -e .[test]
+    pip install -r requirements-dev.txt
     python setup.py develop
   elif [ "$TEST_TYPE" = lint ]; then
     pip install flake8

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ py.test PATH/TO/MY/DIR/ # All tests in directory
 ```
 
 Add the `-s` flag if you have introduced breakpoints into the code for debugging.
-Add the `-v` ("verbose") flag to get more detailed test output. For even more detailed output, use `-vv`. 
+Add the `-v` ("verbose") flag to get more detailed test output. For even more detailed output, use `-vv`.
 Check out the [pytest documentation](https://docs.pytest.org/en/latest/) for more options and test running controls.  
 
 You can also run the benchmarks with:
@@ -96,15 +96,15 @@ You can also run the benchmarks with:
 py.test graphene --benchmark-only
 ```
 
-Graphene supports several versions of Python. To make sure that changes do not break compatibility with any of those versions, we use `tox` to create virtualenvs for each python version and run tests with that version. To run against all python versions defined in the `tox.ini` config file, just run: 
+Graphene supports several versions of Python. To make sure that changes do not break compatibility with any of those versions, we use `tox` to create virtualenvs for each python version and run tests with that version. To run against all python versions defined in the `tox.ini` config file, just run:
 ```sh
 tox
 ```
-If you wish to run against a specific version defined in the `tox.ini` file: 
+If you wish to run against a specific version defined in the `tox.ini` file:
 ```sh
 tox -e py36
 ```
-Tox can only use whatever versions of python are installed on your system. When you create a pull request, Travis will also be running the same tests and report the results, so there is no need for potential contributors to try to install every single version of python on their own system ahead of time. We appreciate opening issues and pull requests to make graphene even more stable & useful! 
+Tox can only use whatever versions of python are installed on your system. When you create a pull request, Travis will also be running the same tests and report the results, so there is no need for potential contributors to try to install every single version of python on their own system ahead of time. We appreciate opening issues and pull requests to make graphene even more stable & useful!
 
 ### Documentation
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,12 @@
+-e .
+pytest
+pytest-benchmark
+pytest-cov
+pytest-mock
+snapshottest
+coveralls
+six
+mock
+pytz
+iso8601
+pre-commit

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,6 @@ import re
 import sys
 
 from setuptools import find_packages, setup
-from setuptools.command.test import test as TestCommand
 
 _version_re = re.compile(r'VERSION\s+=\s+(.*)')
 
@@ -22,38 +21,6 @@ except Exception:
 
 sys.path[:] = path_copy
 
-
-class PyTest(TestCommand):
-    user_options = [('pytest-args=', 'a', "Arguments to pass to py.test")]
-
-    def initialize_options(self):
-        TestCommand.initialize_options(self)
-        self.pytest_args = []
-
-    def finalize_options(self):
-        TestCommand.finalize_options(self)
-        self.test_args = []
-        self.test_suite = True
-
-    def run_tests(self):
-        # import here, cause outside the eggs aren't loaded
-        import pytest
-        errno = pytest.main(self.pytest_args)
-        sys.exit(errno)
-
-
-tests_require = [
-    'pytest',
-    'pytest-benchmark',
-    'pytest-cov',
-    'pytest-mock',
-    'snapshottest',
-    'coveralls',
-    'six',
-    'mock',
-    'pytz',
-    'iso8601',
-]
 
 setup(
     name='graphene',
@@ -93,9 +60,7 @@ setup(
         'promise>=2.1,<3',
         'aniso8601>=3,<4',
     ],
-    tests_require=tests_require,
     extras_require={
-        'test': tests_require,
         'django': [
             'graphene-django',
         ],
@@ -103,5 +68,4 @@ setup(
             'graphene-sqlalchemy',
         ]
     },
-    cmdclass={'test': PyTest},
 )

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,8 @@ envlist = flake8,py27,py33,py34,py35,py36,pre-commit,pypy
 skipsdist = true
 
 [testenv]
-deps = .[test]
+deps =
+    -rrequirements-dev.txt
 setenv =
      PYTHONPATH = .:{envdir}
 commands=


### PR DESCRIPTION
Split out from https://github.com/graphql-python/graphene/pull/745

1. Adds a new requirements-dev.txt file to replace test requirements in setup.py
2. Remove `test` command in setup.py