### PR TITLE
Crunch response data

### DIFF
--- a/graphene/utils/crunch.py
+++ b/graphene/utils/crunch.py
@@ -1,0 +1,37 @@
+import json
+from collections import Mapping
+
+
+def to_key(value):
+    return json.dumps(value)
+
+
+def insert(value, index, values):
+    key = to_key(value)
+
+    if key not in index:
+        index[key] = len(values)
+        values.append(value)
+        return len(values) - 1
+
+    return index.get(key)
+
+
+def flatten(data, index, values):
+    if isinstance(data, (list, tuple)):
+        flattened = [flatten(child, index, values) for child in data]
+    elif isinstance(data, Mapping):
+        flattened = {
+            key: flatten(child, index, values) for key, child in data.items()
+        }
+    else:
+        flattened = data
+    return insert(flattened, index, values)
+
+
+def crunch(data):
+    index = {}
+    values = []
+
+    flatten(data, index, values)
+    return values

--- a/graphene/utils/tests/test_crunch.py
+++ b/graphene/utils/tests/test_crunch.py
@@ -1,4 +1,5 @@
 import pytest
+from collections import OrderedDict
 
 from ..crunch import crunch
 
@@ -17,22 +18,29 @@ from ..crunch import crunch
     ['single-item object', {'a': None}, [None, {'a': 0}]],
     [
         'multi-item all distinct object',
-        {'a': None, 'b': 0, 'c': True, 'd': "string"},
+        OrderedDict([('a', None), ('b', 0), ('c', True), ('d', 'string')]),
         [None, 0, True, "string", {'a': 0, 'b': 1, 'c': 2, 'd': 3}]
     ],
     [
         'multi-item repeated object',
-        {'a': True, 'b': True, 'c': True, 'd': True},
+        OrderedDict([('a', True), ('b', True), ('c', True), ('d', True)]),
         [True, {'a': 0, 'b': 0, 'c': 0, 'd': 0}]
     ],
     [
         'complex array',
-        [{'a': True, 'b': [1, 2, 3]}, [1, 2, 3]],
+        [
+            OrderedDict([('a', True), ('b', [1, 2, 3])]),
+            [1, 2, 3]
+        ],
         [True, 1, 2, 3, [1, 2, 3], {'a': 0, 'b': 4}, [5, 4]]
     ],
     [
         'complex object',
-        {'a': True, 'b': [1, 2, 3], 'c': {'a': True, 'b': [1, 2, 3]}},
+        OrderedDict([
+            ('a', True),
+            ('b', [1, 2, 3]),
+            ('c', OrderedDict([('a', True), ('b', [1, 2, 3])]))
+        ]),
         [True, 1, 2, 3, [1, 2, 3], {'a': 0, 'b': 4}, {'a': 0, 'b': 4, 'c': 5}]
     ],
 ])

--- a/graphene/utils/tests/test_crunch.py
+++ b/graphene/utils/tests/test_crunch.py
@@ -1,0 +1,40 @@
+import pytest
+
+from ..crunch import crunch
+
+
+@pytest.mark.parametrize("description,uncrunched,crunched", [
+    ['number primitive', 0, [0]],
+    ['boolean primitive', True, [True]],
+    ['string primitive', "string", ["string"]],
+    ['empty array', [], [[]]],
+    ['single-item array', [None], [None, [0]]],
+    ['multi-primitive all distinct array', [None, 0, True, "string"], [None, 0, True, "string", [0, 1, 2, 3]]],
+    ['multi-primitive repeated array', [True, True, True, True], [True, [0, 0, 0, 0]]],
+    ['one-level nested array', [[1, 2, 3]], [1, 2, 3, [0, 1, 2], [3]]],
+    ['two-level nested array', [[[1, 2, 3]]], [1, 2, 3, [0, 1, 2], [3], [4]]],
+    ['empty object', {}, [{}]],
+    ['single-item object', {'a': None}, [None, {'a': 0}]],
+    [
+        'multi-item all distinct object',
+        {'a': None, 'b': 0, 'c': True, 'd': "string"},
+        [None, 0, True, "string", {'a': 0, 'b': 1, 'c': 2, 'd': 3}]
+    ],
+    [
+        'multi-item repeated object',
+        {'a': True, 'b': True, 'c': True, 'd': True},
+        [True, {'a': 0, 'b': 0, 'c': 0, 'd': 0}]
+    ],
+    [
+        'complex array',
+        [{'a': True, 'b': [1, 2, 3]}, [1, 2, 3]],
+        [True, 1, 2, 3, [1, 2, 3], {'a': 0, 'b': 4}, [5, 4]]
+    ],
+    [
+        'complex object',
+        {'a': True, 'b': [1, 2, 3], 'c': {'a': True, 'b': [1, 2, 3]}},
+        [True, 1, 2, 3, [1, 2, 3], {'a': 0, 'b': 4}, {'a': 0, 'b': 4, 'c': 5}]
+    ],
+])
+def test_crunch(description, uncrunched, crunched):
+    assert crunch(uncrunched) == crunched


### PR DESCRIPTION
Similar to https://github.com/graphql-python/graphene/pull/786 this PR implements graphql-crunch in python.

Unfortunately I'm not seeing any benefit when running it on our code base (it actually increases response size by a bit) but hopefully it's useful for someone else.