### PR TITLE
Change deprecated execute() arguments to new ones

### DIFF
--- a/docs/execution/execute.rst
+++ b/docs/execution/execute.rst
@@ -16,7 +16,7 @@ For executing a query a schema, you can directly call the ``execute`` method on 
 Context
 _______
 
-You can pass context to a query via ``context_value``.
+You can pass context to a query via ``context``.
 
 
 .. code:: python
@@ -28,14 +28,14 @@ You can pass context to a query via ``context_value``.
             return info.context.get('name')
 
     schema = graphene.Schema(Query)
-    result = schema.execute('{ name }', context_value={'name': 'Syrus'})
+    result = schema.execute('{ name }', context={'name': 'Syrus'})
 
 
 
 Variables
 _______
 
-You can pass variables to a query via ``variable_values``.
+You can pass variables to a query via ``variables``.
 
 
 .. code:: python
@@ -55,5 +55,5 @@ You can pass variables to a query via ``variable_values``.
                 lastName
             }
         }''',
-        variable_values={'id': 12},
+        variables={'id': 12},
     )

--- a/docs/testing/index.rst
+++ b/docs/testing/index.rst
@@ -54,7 +54,7 @@ Execute parameters
 ~~~~~~~~~~~~~~~~~~
 
 You can also add extra keyword arguments to the ``execute`` method, such as
-``context_value``, ``root_value``, ``variable_values``, ...:
+``context``, ``root``, ``variables``, ...:
 
 
 .. code:: python
@@ -63,7 +63,7 @@ You can also add extra keyword arguments to the ``execute`` method, such as
 
     def test_hey():
         client = Client(my_schema)
-        executed = client.execute('''{ hey }''', context_value={'user': 'Peter'})
+        executed = client.execute('''{ hey }''', context={'user': 'Peter'})
         assert executed == {
             'data': {
                 'hey': 'hello Peter!'

--- a/examples/context_example.py
+++ b/examples/context_example.py
@@ -25,11 +25,11 @@ query = """
 
 
 def test_query():
-    result = schema.execute(query, context_value={"user": User(id="1", name="Syrus")})
+    result = schema.execute(query, context={"user": User(id="1", name="Syrus")})
     assert not result.errors
     assert result.data == {"me": {"id": "1", "name": "Syrus"}}
 
 
 if __name__ == "__main__":
-    result = schema.execute(query, context_value={"user": User(id="X", name="Console")})
+    result = schema.execute(query, context={"user": User(id="X", name="Console")})
     print(result.data["me"])

--- a/examples/starwars/tests/test_query.py
+++ b/examples/starwars/tests/test_query.py
@@ -72,7 +72,7 @@ def test_fetch_some_id_query(snapshot):
         }
     """
     params = {"someId": "1000"}
-    snapshot.assert_match(client.execute(query, variable_values=params))
+    snapshot.assert_match(client.execute(query, variables=params))
 
 
 def test_fetch_some_id_query2(snapshot):
@@ -84,7 +84,7 @@ def test_fetch_some_id_query2(snapshot):
         }
     """
     params = {"someId": "1002"}
-    snapshot.assert_match(client.execute(query, variable_values=params))
+    snapshot.assert_match(client.execute(query, variables=params))
 
 
 def test_invalid_id_query(snapshot):
@@ -96,7 +96,7 @@ def test_invalid_id_query(snapshot):
         }
     """
     params = {"id": "not a valid id"}
-    snapshot.assert_match(client.execute(query, variable_values=params))
+    snapshot.assert_match(client.execute(query, variables=params))
 
 
 def test_fetch_luke_aliased(snapshot):

--- a/graphene/types/tests/test_datetime.py
+++ b/graphene/types/tests/test_datetime.py
@@ -90,7 +90,7 @@ def test_datetime_query_variable():
 
     result = schema.execute(
         """query Test($date: DateTime){ datetime(in: $date) }""",
-        variable_values={"date": isoformat},
+        variables={"date": isoformat},
     )
     assert not result.errors
     assert result.data == {"datetime": isoformat}
@@ -102,7 +102,7 @@ def test_date_query_variable():
 
     result = schema.execute(
         """query Test($date: Date){ date(in: $date) }""",
-        variable_values={"date": isoformat},
+        variables={"date": isoformat},
     )
     assert not result.errors
     assert result.data == {"date": isoformat}
@@ -115,7 +115,7 @@ def test_time_query_variable():
 
     result = schema.execute(
         """query Test($time: Time){ time(at: $time) }""",
-        variable_values={"time": isoformat},
+        variables={"time": isoformat},
     )
     assert not result.errors
     assert result.data == {"time": isoformat}

--- a/graphene/types/tests/test_datetime.py
+++ b/graphene/types/tests/test_datetime.py
@@ -101,8 +101,7 @@ def test_date_query_variable():
     isoformat = now.isoformat()
 
     result = schema.execute(
-        """query Test($date: Date){ date(in: $date) }""",
-        variables={"date": isoformat},
+        """query Test($date: Date){ date(in: $date) }""", variables={"date": isoformat}
     )
     assert not result.errors
     assert result.data == {"date": isoformat}
@@ -114,8 +113,7 @@ def test_time_query_variable():
     isoformat = time.isoformat()
 
     result = schema.execute(
-        """query Test($time: Time){ time(at: $time) }""",
-        variables={"time": isoformat},
+        """query Test($time: Time){ time(at: $time) }""", variables={"time": isoformat}
     )
     assert not result.errors
     assert result.data == {"time": isoformat}

--- a/graphene/types/tests/test_decimal.py
+++ b/graphene/types/tests/test_decimal.py
@@ -28,7 +28,7 @@ def test_decimal_string_query_variable():
 
     result = schema.execute(
         """query Test($decimal: Decimal){ decimal(input: $decimal) }""",
-        variable_values={"decimal": decimal_value},
+        variables={"decimal": decimal_value},
     )
     assert not result.errors
     assert result.data == {"decimal": str(decimal_value)}

--- a/graphene/types/tests/test_generic.py
+++ b/graphene/types/tests/test_generic.py
@@ -39,7 +39,7 @@ def test_generic_query_variable():
     ]:
         result = schema.execute(
             """query Test($generic: GenericScalar){ generic(input: $generic) }""",
-            variable_values={"generic": generic_value},
+            variables={"generic": generic_value},
         )
         assert not result.errors
         assert result.data == {"generic": generic_value}

--- a/graphene/types/tests/test_json.py
+++ b/graphene/types/tests/test_json.py
@@ -28,7 +28,7 @@ def test_jsonstring_query_variable():
 
     result = schema.execute(
         """query Test($json: JSONString){ json(input: $json) }""",
-        variable_values={"json": json_value},
+        variables={"json": json_value},
     )
     assert not result.errors
     assert result.data == {"json": json_value}

--- a/graphene/types/tests/test_query.py
+++ b/graphene/types/tests/test_query.py
@@ -464,7 +464,7 @@ def test_query_annotated_resolvers():
     assert not result.errors
     assert result.data == {"annotated": "base-self"}
 
-    result = test_schema.execute("{ context }", "base", context_value=context)
+    result = test_schema.execute("{ context }", "base", context=context)
     assert not result.errors
     assert result.data == {"context": "base-context"}
 

--- a/graphene/types/tests/test_uuid.py
+++ b/graphene/types/tests/test_uuid.py
@@ -25,7 +25,7 @@ def test_uuidstring_query_variable():
 
     result = schema.execute(
         """query Test($uuid: UUID){ uuid(input: $uuid) }""",
-        variable_values={"uuid": uuid_value},
+        variables={"uuid": uuid_value},
     )
     assert not result.errors
     assert result.data == {"uuid": uuid_value}


### PR DESCRIPTION
Changed in https://github.com/graphql-python/graphql-core/pull/185 , the docs here were out of date, as were the tests.