### PR TITLE
Expose documentation for Union types

### DIFF
--- a/graphene/types/typemap.py
+++ b/graphene/types/typemap.py
@@ -255,6 +255,7 @@ class TypeMap(GraphQLTypeMap):
         return GrapheneUnionType(
             graphene_type=type,
             name=type._meta.name,
+            description=type._meta.description,
             types=types,
             resolve_type=_resolve_type,
         )


### PR DESCRIPTION
I noticed this was missing. Not sure if there's a reason that it's missing, but this certainly seems to be supported in schemas, SDL, GraphiQL, etc.