### PR TITLE
Fix Mutation Input inheritance to enable overriding

### DIFF
--- a/graphene/relay/mutation.py
+++ b/graphene/relay/mutation.py
@@ -20,9 +20,9 @@ class ClientIDMutation(Mutation):
         assert not output, "Can't specify any output"
         assert not arguments, "Can't specify any arguments"
 
-        bases = (InputObjectType, )
+        bases = (InputObjectType,)
         if input_class:
-            bases = (input_class, ) + bases
+            bases = (input_class,) + bases
 
         if not input_fields:
             input_fields = {}

--- a/graphene/relay/mutation.py
+++ b/graphene/relay/mutation.py
@@ -20,9 +20,9 @@ class ClientIDMutation(Mutation):
         assert not output, "Can't specify any output"
         assert not arguments, "Can't specify any arguments"
 
-        bases = (InputObjectType,)
+        bases = (InputObjectType, )
         if input_class:
-            bases += (input_class,)
+            bases = (input_class, ) + bases
 
         if not input_fields:
             input_fields = {}


### PR DESCRIPTION
This looks like it's intended to allow for mixins to mutation input types, however the ordering means that `InputObjectType` is the first in the inheritance tree, and it doesn't necessarily always call super, restricting customisation.

This PR re-orders the inheritance so that we can override behaviour on `InputObjectType`.

If I've missed a use-case for why it's this way around do let me know, but I can't think of one. This change was required in order to override the description of the payload type for the mutation.