### PR TITLE
Add basic type documentation for Relay fields

### DIFF
--- a/graphene/relay/connection.py
+++ b/graphene/relay/connection.py
@@ -88,8 +88,22 @@ class Connection(ObjectType):
         _meta.node = node
         _meta.fields = OrderedDict(
             [
-                ("page_info", Field(PageInfo, name="pageInfo", required=True)),
-                ("edges", Field(NonNull(List(edge)))),
+                (
+                    "page_info",
+                    Field(
+                        PageInfo,
+                        name="pageInfo",
+                        required=True,
+                        description="Pagination data for this connection.",
+                    ),
+                ),
+                (
+                    "edges",
+                    Field(
+                        NonNull(List(edge)),
+                        description="Contains the nodes in this connection.",
+                    ),
+                ),
             ]
         )
         return super(Connection, cls).__init_subclass_with_meta__(

--- a/graphene/relay/connection.py
+++ b/graphene/relay/connection.py
@@ -12,6 +12,12 @@ from .node import is_node
 
 
 class PageInfo(ObjectType):
+    class Meta:
+        description = (
+            "The Relay compliant `PageInfo` type, containing data necessary to"
+            " paginate this connection."
+        )
+
     has_next_page = Boolean(
         required=True,
         name="hasNextPage",
@@ -64,13 +70,18 @@ class Connection(ObjectType):
             node = Field(_node, description="The item at the end of the edge")
             cursor = String(required=True, description="A cursor for use in pagination")
 
+        class EdgeMeta:
+            description = "A Relay edge containing a `{}` and its cursor.".format(
+                base_name
+            )
+
         edge_name = "{}Edge".format(base_name)
         if edge_class:
             edge_bases = (edge_class, EdgeBase, ObjectType)
         else:
             edge_bases = (EdgeBase, ObjectType)
 
-        edge = type(edge_name, edge_bases, {})
+        edge = type(edge_name, edge_bases, {"Meta": EdgeMeta})
         cls.Edge = edge
 
         options["name"] = name


### PR DESCRIPTION
This adds documentation in the API for `PageInfo`s and `Edges`.

This is useful to include in Graphene because `PageInfo` is always the same, and Edges always have the same format, so documentation for both can be created automatically.