### PR TITLE
Don't enforce python 3.6 on precommit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,4 +21,4 @@ repos:
     rev: 18.6b4
     hooks:
     - id: black
-      language_version: python3.6
+      language_version: python3


### PR DESCRIPTION
Precommit wasn't working for me on Python 3.7