### PR TITLE
Special characters in README.rst break setup.py on Windows

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -30,7 +30,7 @@ server with an associated set of resolve methods that know how to fetch
 data.
 
 We are going to create a very simple schema, with a ``Query`` with only
-one field: ``hello`` and an input name. And when we query it, it should return ``"Hello 
+one field: ``hello`` and an input name. And when we query it, it should return ``"Hello
 {argument}"``.
 
 .. code:: python

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 import ast
+import codecs
 import re
 import sys
 
@@ -61,7 +62,7 @@ setup(
     name="graphene",
     version=version,
     description="GraphQL Framework for Python",
-    long_description=open("README.rst").read(),
+    long_description=codecs.open("README.rst", "r", "utf-8").read(),
     url="https://github.com/graphql-python/graphene",
     author="Syrus Akbary",
     author_email="me@syrusakbary.com",

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ setup(
     name="graphene",
     version=version,
     description="GraphQL Framework for Python",
-    long_description=codecs.open("README.rst", "r", "utf-8").read(),
+    long_description=codecs.open("README.rst", "r", encoding="ascii", errors="replace").read(),
     url="https://github.com/graphql-python/graphene",
     author="Syrus Akbary",
     author_email="me@syrusakbary.com",

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,9 @@ setup(
     name="graphene",
     version=version,
     description="GraphQL Framework for Python",
-    long_description=codecs.open("README.rst", "r", encoding="ascii", errors="replace").read(),
+    long_description=codecs.open(
+        "README.rst", "r", encoding="ascii", errors="replace"
+    ).read(),
     url="https://github.com/graphql-python/graphene",
     author="Syrus Akbary",
     author_email="me@syrusakbary.com",


### PR DESCRIPTION
Fixes #872 

Latest version is forcing `long_description` to ASCII. This is a little invasive but tools reading PKG-INFO seem to struggle with special characters too. 