### PR TITLE
Fix build - Fix missing type annotations

### DIFF
--- a/graphene/types/base.py
+++ b/graphene/types/base.py
@@ -1,5 +1,12 @@
+import six
+
 from ..utils.subclass_with_meta import SubclassWithMeta
 from ..utils.trim_docstring import trim_docstring
+
+if six.PY3:
+    from typing import Type
+else:
+    Type = type
 
 
 class BaseOptions(object):

--- a/graphene/types/base.py
+++ b/graphene/types/base.py
@@ -5,8 +5,6 @@ from ..utils.trim_docstring import trim_docstring
 
 if six.PY3:
     from typing import Type
-else:
-    Type = type
 
 
 class BaseOptions(object):

--- a/graphene/types/scalars.py
+++ b/graphene/types/scalars.py
@@ -4,6 +4,11 @@ from graphql.language.ast import BooleanValue, FloatValue, IntValue, StringValue
 from .base import BaseOptions, BaseType
 from .unmountedtype import UnmountedType
 
+if six.PY3:
+    from typing import Any
+else:
+    Any = object
+
 
 class ScalarOptions(BaseOptions):
     pass

--- a/graphene/types/scalars.py
+++ b/graphene/types/scalars.py
@@ -6,8 +6,6 @@ from .unmountedtype import UnmountedType
 
 if six.PY3:
     from typing import Any
-else:
-    Any = object
 
 
 class ScalarOptions(BaseOptions):


### PR DESCRIPTION
`flake8` was Failing in Python 3.6 on not having `Type` and `Any` definitions.
These are special Python typing definitions so to fix this in Python3.6+ we need to:
`from typing import Type, Any`

In Python2, this is kind of meaningless so I just fake them to be
```
Type = type
Any = object
```