### PR TITLE
Allow initialization of ObjectType with dynamic private state

### DIFF
--- a/graphene/tests/issues/test_870.py
+++ b/graphene/tests/issues/test_870.py
@@ -1,0 +1,80 @@
+import graphene
+
+
+class SecondChild(graphene.ObjectType):
+    hello = graphene.String()
+
+
+def resolve_second_child(self, info):
+    return SecondChild(hello=self.second_child._test)
+
+
+second_child_f = graphene.Field(SecondChild, resolver=resolve_second_child)
+
+
+class FirstChild(graphene.ObjectType):
+    hello = graphene.String()
+    second_child = second_child_f
+
+
+def resolve_first_child(self, info):
+    message = self.first_child._test + " stranger"
+
+    test_case = {"_test": message}
+
+    return FirstChild(
+        hello=self.first_child._test, second_child=SecondChild(**test_case)
+    )
+
+
+first_child_f = graphene.Field(FirstChild, resolver=resolve_first_child)
+
+
+class ParentQuery(graphene.ObjectType):
+    hello = graphene.String()
+    first_child = first_child_f
+
+
+def resolve_parent(self, info, **args):
+
+    message = args.get("greeting") + " there"
+
+    test_case = {"_test": message}
+
+    return ParentQuery(hello=args.get("greeting"), first_child=FirstChild(**test_case))
+
+
+parent = graphene.Field(
+    ParentQuery, resolver=resolve_parent, greeting=graphene.Argument(graphene.String)
+)
+
+
+class Query(graphene.ObjectType):
+    final = parent
+
+
+def test_issue():
+    query_string = """
+    query {
+        final (greeting: "hi") {
+            hello
+            firstChild {
+                hello
+                secondChild {
+                    hello
+                }
+            }
+        }
+    }
+    """
+
+    schema = graphene.Schema(query=Query)
+    result = schema.execute(query_string)
+
+    assert not result.errors
+    assert result.data["final"]["hello"] == "hi"
+    assert result.data["final"]["firstChild"]["hello"] == "hi there"
+    assert (
+        result.data["final"]["firstChild"]["secondChild"]["hello"]
+        == "hi there stranger"
+    )

--- a/graphene/types/objecttype.py
+++ b/graphene/types/objecttype.py
@@ -95,7 +95,7 @@ class ObjectType(BaseType):
             for prop in list(kwargs):
                 try:
                     if isinstance(
-                        getattr(self.__class__, prop), property
+                        getattr(self.__class__, prop, None), property
                     ) or prop.startswith("_"):
                         setattr(self, prop, kwargs.pop(prop))
                 except AttributeError:

--- a/graphene/types/tests/test_objecttype.py
+++ b/graphene/types/tests/test_objecttype.py
@@ -92,7 +92,7 @@ def test_generate_objecttype_with_private_attributes():
     assert m._private_state == "custom"
 
     m = MyObjectType(_other_private_state="custom")
-    assert hasattr(MyObjectType, "_private_state")
+    assert hasattr(m, "_other_private_state")
 
 
 def test_ordered_fields_in_objecttype():

--- a/graphene/types/tests/test_objecttype.py
+++ b/graphene/types/tests/test_objecttype.py
@@ -91,8 +91,8 @@ def test_generate_objecttype_with_private_attributes():
     m = MyObjectType(_private_state="custom")
     assert m._private_state == "custom"
 
-    with pytest.raises(TypeError):
-        MyObjectType(_other_private_state="Wrong")
+    m = MyObjectType(_other_private_state="custom")
+    assert getattr(m, "_other_private_state", None) is "custom"
 
 
 def test_ordered_fields_in_objecttype():

--- a/graphene/types/tests/test_objecttype.py
+++ b/graphene/types/tests/test_objecttype.py
@@ -92,7 +92,7 @@ def test_generate_objecttype_with_private_attributes():
     assert m._private_state == "custom"
 
     m = MyObjectType(_other_private_state="custom")
-    assert getattr(m, "_other_private_state", None) is "custom"
+    assert hasattr(MyObjectType, "_private_state")
 
 
 def test_ordered_fields_in_objecttype():


### PR DESCRIPTION
Proposing change to concept of "private state" to allow for more dynamic assignment.

While looking into patterns to pass data from parent -> child (https://github.com/graphql-python/graphene/issues/870), found that `ObjectType` could use `kwarg` prepended by an `_`.  At first thought there was a bug (https://github.com/graphql-python/graphene/blob/master/graphene/types/objecttype.py#L98) where `getattr` was missing a default of `None`, but later found in test case that may have been intentional (https://github.com/graphql-python/graphene/commit/2975e1fc42709cfd8c2331a57dd91091f6ad2ef4#diff-a76bb330091e6980d5fe6d9e5958a2edR78) to force explicit declaration.

From my view point, there are benefits to allow dynamic `kwarg`, especially for use cases with differentiated resolvers (ie, resolve one way when a parent node, another when a child, a third when a child of a child).

Either way, I think this capability should also be surfaced in the documentation. Happy to also take that on if we can establish the "graphenic" way of doing it. 