### PR TITLE
Allow the Connection node to be wrapped in a `NonNull` type

### DIFF
--- a/graphene/relay/connection.py
+++ b/graphene/relay/connection.py
@@ -53,7 +53,7 @@ class Connection(ObjectType):
     def __init_subclass_with_meta__(cls, node=None, name=None, **options):
         _meta = ConnectionOptions(cls)
         assert node, "You have to provide a node in {}.Meta".format(cls.__name__)
-        assert issubclass(
+        assert isinstance(node, NonNull) or issubclass(
             node, (Scalar, Enum, ObjectType, Interface, Union, NonNull)
         ), ('Received incompatible node "{}" for Connection {}.').format(
             node, cls.__name__

--- a/graphene/relay/tests/test_connection.py
+++ b/graphene/relay/tests/test_connection.py
@@ -108,6 +108,17 @@ def test_edge_with_bases():
     assert edge_fields["other"].type == String
 
 
+def test_edge_with_nonnull_node():
+    class MyObjectConnection(Connection):
+        class Meta:
+            node = NonNull(MyObject)
+
+    edge_fields = MyObjectConnection.Edge._meta.fields
+    assert isinstance(edge_fields["node"], Field)
+    assert isinstance(edge_fields["node"].type, NonNull)
+    assert edge_fields["node"].type.of_type == MyObject
+
+
 def test_pageinfo():
     assert PageInfo._meta.name == "PageInfo"
     fields = PageInfo._meta.fields


### PR DESCRIPTION
When we declare the Connection `node` to be `NonNull` like below,
```python
class MyConnection(Connection):
    class Meta:
        node = NonNull(String)
```
we fail the assertion 
```python
assert issubclass(node, (Scalar, Enum, ObjectType, Interface, Union, NonNull))
```

However, this should be allowed according to the [Relay Connection specification](https://facebook.github.io/relay/graphql/connections.htm#sec-Node),
> An “Edge Type” must contain a field called node. This field must return either a Scalar, Enum, Object, Interface, Union, or a Non‐Null wrapper around one of those types.

Alternatively, we could define the `Edge` in the connection.
```python
class MyConnection(Connection):
    class Meta:
        node = String # We have another assertion that make this `Meta` field required!

    class Edge:
        node = NonNull(String)
```
However, from the assertion that `Meta`'s `node` field is required, `Edge`  isn't meant to be used to declare `node`.