### PR TITLE
Update aniso8601 dependency to allow versions 4+.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,7 @@ setup(
         "six>=1.10.0,<2",
         "graphql-core>=2.1,<3",
         "graphql-relay>=0.4.5,<1",
-        "aniso8601>=3",
+        "aniso8601>=3,<=6.0.*",
     ],
     tests_require=tests_require,
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,7 @@ setup(
         "six>=1.10.0,<2",
         "graphql-core>=2.1,<3",
         "graphql-relay>=0.4.5,<1",
-        "aniso8601>=3,<4",
+        "aniso8601>=3",
     ],
     tests_require=tests_require,
     extras_require={


### PR DESCRIPTION
I accidentally updated my local aniso8601 to 6.0.0. My projects were running fine with graphene==2.1.3 and aniso8601==6.0.0. Later, I noticed the pip warnings telling me they were incompatible versions.

I ran tox against aniso8601 versions 4.0.0, 5.0.0, and 6.0.0 and compared against the results from running against 3.0.2. Results look the same at a glance.
