### PR TITLE
Change asserts to manually raising AssertionError

### DIFF
--- a/graphene/relay/connection.py
+++ b/graphene/relay/connection.py
@@ -52,12 +52,18 @@ class Connection(ObjectType):
     @classmethod
     def __init_subclass_with_meta__(cls, node=None, name=None, **options):
         _meta = ConnectionOptions(cls)
-        assert node, "You have to provide a node in {}.Meta".format(cls.__name__)
-        assert isinstance(node, NonNull) or issubclass(
+        if not node:
+            raise AssertionError(
+                "You have to provide a node in {}.Meta".format(cls.__name__)
+            )
+        if not isinstance(node, NonNull) and not issubclass(
             node, (Scalar, Enum, ObjectType, Interface, Union, NonNull)
-        ), ('Received incompatible node "{}" for Connection {}.').format(
-            node, cls.__name__
-        )
+        ):
+            raise AssertionError(
+                ('Received incompatible node "{}" for Connection {}.').format(
+                    node, cls.__name__
+                )
+            )
 
         base_name = re.sub("Connection$", "", name or cls.__name__) or node._meta.name
         if not name:
@@ -132,9 +138,12 @@ class IterableConnectionField(Field):
                 "Read more: https://github.com/graphql-python/graphene/blob/v2.0.0/UPGRADE-v2.0.md#node-connections"
             )
 
-        assert issubclass(connection_type, Connection), (
-            '{} type have to be a subclass of Connection. Received "{}".'
-        ).format(self.__class__.__name__, connection_type)
+        if not issubclass(connection_type, Connection):
+            raise AssertionError(
+                ('{} type have to be a subclass of Connection. Received "{}".').format(
+                    self.__class__.__name__, connection_type
+                )
+            )
         return type
 
     @classmethod
@@ -142,10 +151,13 @@ class IterableConnectionField(Field):
         if isinstance(resolved, connection_type):
             return resolved
 
-        assert isinstance(resolved, Iterable), (
-            "Resolved value from the connection field have to be iterable or instance of {}. "
-            'Received "{}"'
-        ).format(connection_type, resolved)
+        if not isinstance(resolved, Iterable):
+            raise AssertionError(
+                (
+                    "Resolved value from the connection field have to be iterable "
+                    'or instance of {}. Received "{}"'
+                ).format(connection_type, resolved)
+            )
         connection = connection_from_list(
             resolved,
             args,

--- a/graphene/relay/mutation.py
+++ b/graphene/relay/mutation.py
@@ -17,8 +17,10 @@ class ClientIDMutation(Mutation):
         input_class = getattr(cls, "Input", None)
         base_name = re.sub("Payload$", "", name or cls.__name__)
 
-        assert not output, "Can't specify any output"
-        assert not arguments, "Can't specify any arguments"
+        if output:
+            raise AssertionError("Can't specify any output")
+        if arguments:
+            raise AssertionError("Can't specify any arguments")
 
         bases = (InputObjectType,)
         if input_class:
@@ -41,10 +43,13 @@ class ClientIDMutation(Mutation):
         )
         mutate_and_get_payload = getattr(cls, "mutate_and_get_payload", None)
         if cls.mutate and cls.mutate.__func__ == ClientIDMutation.mutate.__func__:
-            assert mutate_and_get_payload, (
-                "{name}.mutate_and_get_payload method is required"
-                " in a ClientIDMutation."
-            ).format(name=name or cls.__name__)
+            if not mutate_and_get_payload:
+                raise AssertionError(
+                    (
+                        "{name}.mutate_and_get_payload method is required"
+                        " in a ClientIDMutation."
+                    ).format(name=name or cls.__name__)
+                )
 
         if not name:
             name = "{}Payload".format(base_name)

--- a/graphene/relay/node.py
+++ b/graphene/relay/node.py
@@ -49,7 +49,8 @@ class GlobalID(Field):
 
 class NodeField(Field):
     def __init__(self, node, type=False, deprecation_reason=None, name=None, **kwargs):
-        assert issubclass(node, Node), "NodeField can only operate in Nodes"
+        if not issubclass(node, Node):
+            raise AssertionError("NodeField can only operate in Nodes")
         self.node_type = node
         self.field_type = type
 
@@ -98,9 +99,10 @@ class Node(AbstractNode):
             return None
 
         if only_type:
-            assert graphene_type == only_type, ("Must receive a {} id.").format(
-                only_type._meta.name
-            )
+            if graphene_type != only_type:
+                raise AssertionError(
+                    ("Must receive a {} id.").format(only_type._meta.name)
+                )
 
         # We make sure the ObjectType implements the "Node" interface
         if cls not in graphene_type._meta.interfaces:

--- a/graphene/types/argument.py
+++ b/graphene/types/argument.py
@@ -73,9 +73,10 @@ def to_arguments(args, extra_args=None):
             raise ValueError('Unknown argument "{}".'.format(default_name))
 
         arg_name = default_name or arg.name
-        assert (
-            arg_name not in arguments
-        ), 'More than one Argument have same name "{}".'.format(arg_name)
+        if arg_name in arguments:
+            raise AssertionError(
+                'More than one Argument have same name "{}".'.format(arg_name)
+            )
         arguments[arg_name] = arg
 
     return arguments

--- a/graphene/types/base.py
+++ b/graphene/types/base.py
@@ -35,7 +35,8 @@ class BaseType(SubclassWithMeta):
 
     @classmethod
     def __init_subclass_with_meta__(cls, name=None, description=None, _meta=None):
-        assert "_meta" not in cls.__dict__, "Can't assign directly meta"
+        if "_meta" in cls.__dict__:
+            raise AssertionError("Can't assign directly meta")
         if not _meta:
             return
         _meta.name = name or cls.__name__

--- a/graphene/types/datetime.py
+++ b/graphene/types/datetime.py
@@ -20,9 +20,8 @@ class Date(Scalar):
     def serialize(date):
         if isinstance(date, datetime.datetime):
             date = date.date()
-        assert isinstance(
-            date, datetime.date
-        ), 'Received not compatible date "{}"'.format(repr(date))
+        if not isinstance(date, datetime.date):
+            raise AssertionError('Received not compatible date "{}"'.format(repr(date)))
         return date.isoformat()
 
     @classmethod
@@ -50,9 +49,10 @@ class DateTime(Scalar):
 
     @staticmethod
     def serialize(dt):
-        assert isinstance(
-            dt, (datetime.datetime, datetime.date)
-        ), 'Received not compatible datetime "{}"'.format(repr(dt))
+        if not isinstance(dt, (datetime.datetime, datetime.date)):
+            raise AssertionError(
+                'Received not compatible datetime "{}"'.format(repr(dt))
+            )
         return dt.isoformat()
 
     @classmethod
@@ -80,9 +80,8 @@ class Time(Scalar):
 
     @staticmethod
     def serialize(time):
-        assert isinstance(
-            time, datetime.time
-        ), 'Received not compatible time "{}"'.format(repr(time))
+        if not isinstance(time, datetime.time):
+            raise AssertionError('Received not compatible time "{}"'.format(repr(time)))
         return time.isoformat()
 
     @classmethod

--- a/graphene/types/decimal.py
+++ b/graphene/types/decimal.py
@@ -16,9 +16,10 @@ class Decimal(Scalar):
     def serialize(dec):
         if isinstance(dec, str):
             dec = _Decimal(dec)
-        assert isinstance(dec, _Decimal), 'Received not compatible Decimal "{}"'.format(
-            repr(dec)
-        )
+        if not isinstance(dec, _Decimal):
+            raise AssertionError(
+                'Received not compatible Decimal "{}"'.format(repr(dec))
+            )
         return str(dec)
 
     @classmethod

--- a/graphene/types/dynamic.py
+++ b/graphene/types/dynamic.py
@@ -12,7 +12,8 @@ class Dynamic(MountedType):
 
     def __init__(self, type, with_schema=False, _creation_counter=None):
         super(Dynamic, self).__init__(_creation_counter=_creation_counter)
-        assert inspect.isfunction(type) or isinstance(type, partial)
+        if not inspect.isfunction(type) and not isinstance(type, partial):
+            raise AssertionError()
         self.type = type
         self.with_schema = with_schema
 

--- a/graphene/types/field.py
+++ b/graphene/types/field.py
@@ -34,15 +34,22 @@ class Field(MountedType):
         **extra_args
     ):
         super(Field, self).__init__(_creation_counter=_creation_counter)
-        assert not args or isinstance(args, Mapping), (
-            'Arguments in a field have to be a mapping, received "{}".'
-        ).format(args)
-        assert not (
-            source and resolver
-        ), "A Field cannot have a source and a resolver in at the same time."
-        assert not callable(default_value), (
-            'The default value can not be a function but received "{}".'
-        ).format(base_type(default_value))
+        if args and not isinstance(args, Mapping):
+            raise AssertionError(
+                ('Arguments in a field have to be a mapping, received "{}".').format(
+                    args
+                )
+            )
+        if source and resolver:
+            raise AssertionError(
+                "A Field cannot have a source and a resolver " "in at the same time."
+            )
+        if callable(default_value):
+            raise AssertionError(
+                ('The default value can not be a function but received "{}".').format(
+                    base_type(default_value)
+                )
+            )
 
         if required:
             type = NonNull(type)

--- a/graphene/types/mountedtype.py
+++ b/graphene/types/mountedtype.py
@@ -8,9 +8,10 @@ class MountedType(OrderedType):
         """
         Mount the UnmountedType instance
         """
-        assert isinstance(unmounted, UnmountedType), ("{} can't mount {}").format(
-            cls.__name__, repr(unmounted)
-        )
+        if not isinstance(unmounted, UnmountedType):
+            raise AssertionError(
+                ("{} can't mount {}").format(cls.__name__, repr(unmounted))
+            )
 
         return cls(
             unmounted.get_type(),

--- a/graphene/types/mutation.py
+++ b/graphene/types/mutation.py
@@ -62,7 +62,8 @@ class Mutation(ObjectType):
 
         if not resolver:
             mutate = getattr(cls, "mutate", None)
-            assert mutate, "All mutations must define a mutate method in it"
+            if not mutate:
+                raise AssertionError("All mutations must define a mutate method in it")
             resolver = get_unbound_function(mutate)
 
         if _meta.fields:

--- a/graphene/types/objecttype.py
+++ b/graphene/types/objecttype.py
@@ -39,18 +39,25 @@ class ObjectType(BaseType):
         fields = OrderedDict()
 
         for interface in interfaces:
-            assert issubclass(interface, Interface), (
-                'All interfaces of {} must be a subclass of Interface. Received "{}".'
-            ).format(cls.__name__, interface)
+            if not issubclass(interface, Interface):
+                raise AssertionError(
+                    (
+                        "All interfaces of {} must be a subclass of Interface. "
+                        'Received "{}".'
+                    ).format(cls.__name__, interface)
+                )
             fields.update(interface._meta.fields)
 
         for base in reversed(cls.__mro__):
             fields.update(yank_fields_from_attrs(base.__dict__, _as=Field))
 
-        assert not (possible_types and cls.is_type_of), (
-            "{name}.Meta.possible_types will cause type collision with {name}.is_type_of. "
-            "Please use one or other."
-        ).format(name=cls.__name__)
+        if possible_types and cls.is_type_of:
+            raise AssertionError(
+                (
+                    "{name}.Meta.possible_types will cause type collision with "
+                    "{name}.is_type_of. Please use one or other."
+                ).format(name=cls.__name__)
+            )
 
         if _meta.fields:
             _meta.fields.update(fields)

--- a/graphene/types/resolver.py
+++ b/graphene/types/resolver.py
@@ -18,7 +18,8 @@ default_resolver = dict_or_attr_resolver
 
 def set_default_resolver(resolver):
     global default_resolver
-    assert callable(resolver), "Received non-callable resolver."
+    if not callable(resolver):
+        raise AssertionError("Received non-callable resolver.")
     default_resolver = resolver
 
 

--- a/graphene/types/schema.py
+++ b/graphene/types/schema.py
@@ -20,9 +20,8 @@ def assert_valid_root_type(_type):
         return
     is_graphene_objecttype = inspect.isclass(_type) and issubclass(_type, ObjectType)
     is_graphql_objecttype = isinstance(_type, GraphQLObjectType)
-    assert is_graphene_objecttype or is_graphql_objecttype, (
-        "Type {} is not a valid ObjectType."
-    ).format(_type)
+    if not is_graphene_objecttype and not is_graphql_objecttype:
+        raise AssertionError(("Type {} is not a valid ObjectType.").format(_type))
 
 
 class Schema(GraphQLSchema):
@@ -53,11 +52,11 @@ class Schema(GraphQLSchema):
         if directives is None:
             directives = [GraphQLIncludeDirective, GraphQLSkipDirective]
 
-        assert all(
-            isinstance(d, GraphQLDirective) for d in directives
-        ), "Schema directives must be List[GraphQLDirective] if provided but got: {}.".format(
-            directives
-        )
+        if not all(isinstance(d, GraphQLDirective) for d in directives):
+            raise AssertionError(
+                "Schema directives must be List[GraphQLDirective] if provided "
+                "but got: {}.".format(directives)
+            )
         self._directives = directives
         self.build_typemap()
 
@@ -91,10 +90,12 @@ class Schema(GraphQLSchema):
             return _type
         if is_graphene_type(_type):
             graphql_type = self.get_type(_type._meta.name)
-            assert graphql_type, "Type {} not found in this schema.".format(
-                _type._meta.name
-            )
-            assert graphql_type.graphene_type == _type
+            if not graphql_type:
+                raise AssertionError(
+                    "Type {} not found in this schema.".format(_type._meta.name)
+                )
+            if graphql_type.graphene_type != _type:
+                raise AssertionError()
             return graphql_type
         raise Exception("{} is not a valid GraphQL type.".format(_type))
 

--- a/graphene/types/structures.py
+++ b/graphene/types/structures.py
@@ -67,9 +67,12 @@ class NonNull(Structure):
 
     def __init__(self, *args, **kwargs):
         super(NonNull, self).__init__(*args, **kwargs)
-        assert not isinstance(self._of_type, NonNull), (
-            "Can only create NonNull of a Nullable GraphQLType but got: {}."
-        ).format(self._of_type)
+        if isinstance(self._of_type, NonNull):
+            raise AssertionError(
+                (
+                    "Can only create NonNull of a Nullable GraphQLType but got: {}."
+                ).format(self._of_type)
+            )
 
     def __str__(self):
         return "{}!".format(self.of_type)

--- a/graphene/types/typemap.py
+++ b/graphene/types/typemap.py
@@ -60,10 +60,16 @@ def resolve_type(resolve_type_func, map, type_name, root, info):
 
     if inspect.isclass(_type) and issubclass(_type, ObjectType):
         graphql_type = map.get(_type._meta.name)
-        assert graphql_type, "Can't find type {} in schema".format(_type._meta.name)
-        assert graphql_type.graphene_type == _type, (
-            "The type {} does not match with the associated graphene type {}."
-        ).format(_type, graphql_type.graphene_type)
+        if not graphql_type:
+            raise AssertionError(
+                "Can't find type {} in schema".format(_type._meta.name)
+            )
+        if graphql_type.graphene_type != _type:
+            raise AssertionError(
+                (
+                    "The type {} does not match with the associated graphene type {}."
+                ).format(_type, graphql_type.graphene_type)
+            )
         return graphql_type
 
     return _type
@@ -94,9 +100,12 @@ class TypeMap(GraphQLTypeMap):
         if type._meta.name in map:
             _type = map[type._meta.name]
             if isinstance(_type, GrapheneGraphQLType):
-                assert _type.graphene_type == type, (
-                    "Found different types with the same name in the schema: {}, {}."
-                ).format(_type.graphene_type, type)
+                if _type.graphene_type != type:
+                    raise AssertionError(
+                        (
+                            "Found different types with the same name in the schema: {}, {}."
+                        ).format(_type.graphene_type, type)
+                    )
             return map
 
         if issubclass(type, ObjectType):
@@ -173,9 +182,12 @@ class TypeMap(GraphQLTypeMap):
         if type._meta.name in map:
             _type = map[type._meta.name]
             if isinstance(_type, GrapheneGraphQLType):
-                assert _type.graphene_type == type, (
-                    "Found different types with the same name in the schema: {}, {}."
-                ).format(_type.graphene_type, type)
+                if _type.graphene_type != type:
+                    raise AssertionError(
+                        (
+                            "Found different types with the same name in the schema: {}, {}."
+                        ).format(_type.graphene_type, type)
+                    )
             return _type
 
         def interfaces():
@@ -183,7 +195,8 @@ class TypeMap(GraphQLTypeMap):
             for interface in type._meta.interfaces:
                 self.graphene_reducer(map, interface)
                 internal_type = map[interface._meta.name]
-                assert internal_type.graphene_type == interface
+                if internal_type.graphene_type != interface:
+                    raise AssertionError()
                 interfaces.append(internal_type)
             return interfaces
 
@@ -207,9 +220,12 @@ class TypeMap(GraphQLTypeMap):
         if type._meta.name in map:
             _type = map[type._meta.name]
             if isinstance(_type, GrapheneInterfaceType):
-                assert _type.graphene_type == type, (
-                    "Found different types with the same name in the schema: {}, {}."
-                ).format(_type.graphene_type, type)
+                if _type.graphene_type != type:
+                    raise AssertionError(
+                        (
+                            "Found different types with the same name in the schema: {}, {}."
+                        ).format(_type.graphene_type, type)
+                    )
             return _type
 
         _resolve_type = None
@@ -248,7 +264,8 @@ class TypeMap(GraphQLTypeMap):
             for objecttype in type._meta.types:
                 self.graphene_reducer(map, objecttype)
                 internal_type = map[objecttype._meta.name]
-                assert internal_type.graphene_type == objecttype
+                if internal_type.graphene_type != objecttype:
+                    raise AssertionError()
                 union_types.append(internal_type)
             return union_types
 

--- a/graphene/types/union.py
+++ b/graphene/types/union.py
@@ -23,9 +23,10 @@ class Union(UnmountedType, BaseType):
 
     @classmethod
     def __init_subclass_with_meta__(cls, types=None, **options):
-        assert (
-            isinstance(types, (list, tuple)) and len(types) > 0
-        ), "Must provide types for Union {name}.".format(name=cls.__name__)
+        if not isinstance(types, (list, tuple)) or not len(types) > 0:
+            raise AssertionError(
+                "Must provide types for Union {name}.".format(name=cls.__name__)
+            )
 
         _meta = UnionOptions(cls)
         _meta.types = types

--- a/graphene/types/uuid.py
+++ b/graphene/types/uuid.py
@@ -15,9 +15,8 @@ class UUID(Scalar):
         if isinstance(uuid, six.string_types):
             uuid = _UUID(uuid)
 
-        assert isinstance(uuid, _UUID), "Expected UUID instance, received {}".format(
-            uuid
-        )
+        if not isinstance(uuid, _UUID):
+            raise AssertionError("Expected UUID instance, received {}".format(uuid))
         return str(uuid)
 
     @staticmethod

--- a/graphene/utils/annotate.py
+++ b/graphene/utils/annotate.py
@@ -22,9 +22,12 @@ def annotate(_func=None, _trigger_warning=True, **annotations):
 
     # We make sure the annotations are valid
     for key, value in annotations.items():
-        assert key in func_signature.parameters, (
-            'The key {key} is not a function parameter in the function "{func_name}".'
-        ).format(key=key, func_name=func_name(_func))
+        if key not in func_signature.parameters:
+            raise AssertionError(
+                (
+                    'The key {key} is not a function parameter in the function "{func_name}".'
+                ).format(key=key, func_name=func_name(_func))
+            )
 
     func_annotations = getattr(_func, "__annotations__", None)
     if func_annotations is None:

--- a/graphene/utils/subclass_with_meta.py
+++ b/graphene/utils/subclass_with_meta.py
@@ -42,10 +42,13 @@ class SubclassWithMeta(six.with_metaclass(SubclassWithMeta_Meta)):
 
         abstract = options.pop("abstract", False)
         if abstract:
-            assert not options, (
-                "Abstract types can only contain the abstract attribute. "
-                "Received: abstract, {option_keys}"
-            ).format(option_keys=", ".join(options.keys()))
+            if options:
+                raise AssertionError(
+                    (
+                        "Abstract types can only contain the abstract attribute. "
+                        "Received: abstract, {option_keys}"
+                    ).format(option_keys=", ".join(options.keys()))
+                )
         else:
             super_class = super(cls, cls)
             if hasattr(super_class, "__init_subclass_with_meta__"):


### PR DESCRIPTION
See graphql-python/graphql-core#244 for discussion of why this change is needed. The issue exists in several `graphql-python` projects (`graphql-core`, `graphene`, `graphene-django`), but biting this one off first as it was smaller than the changes needed in `graphql-core`.

Ideally the usage of `AssertionError` would be dropped in favor of `TypeError` and `ValueError`, but that would have to wait for a new major version release as it's a backwards incompatible change.