### PR TITLE
Fix flaky date tests

### DIFF
--- a/graphene/types/tests/test_datetime.py
+++ b/graphene/types/tests/test_datetime.py
@@ -28,36 +28,47 @@ schema = Schema(query=Query)
 
 
 @pytest.fixture
-def now():
+def sample_datetime():
     utc_datetime = datetime.datetime(2019, 5, 25, 5, 30, 15, 10, pytz.utc)
     return utc_datetime
 
 
 @pytest.fixture
-def time(now):
-    time = datetime.time(now.hour, now.minute, now.second, now.microsecond, now.tzinfo)
+def sample_time(sample_datetime):
+    time = datetime.time(
+        sample_datetime.hour,
+        sample_datetime.minute,
+        sample_datetime.second,
+        sample_datetime.microsecond,
+        sample_datetime.tzinfo,
+    )
     return time
 
 
-def test_datetime_query(now):
-    isoformat = now.isoformat()
+@pytest.fixture
+def sample_date(sample_datetime):
+    date = sample_datetime.date()
+    return date
+
+
+def test_datetime_query(sample_datetime):
+    isoformat = sample_datetime.isoformat()
 
     result = schema.execute("""{ datetime(in: "%s") }""" % isoformat)
     assert not result.errors
     assert result.data == {"datetime": isoformat}
 
 
-def test_date_query(now):
-    now = now.date()
-    isoformat = now.isoformat()
+def test_date_query(sample_date):
+    isoformat = sample_date.isoformat()
 
     result = schema.execute("""{ date(in: "%s") }""" % isoformat)
     assert not result.errors
     assert result.data == {"date": isoformat}
 
 
-def test_time_query(time):
-    isoformat = time.isoformat()
+def test_time_query(sample_time):
+    isoformat = sample_time.isoformat()
 
     result = schema.execute("""{ time(at: "%s") }""" % isoformat)
     assert not result.errors
@@ -94,13 +105,13 @@ def test_bad_time_query():
     assert result.data is None
 
 
-def test_datetime_query_variable(now):
-    isoformat = now.isoformat()
+def test_datetime_query_variable(sample_datetime):
+    isoformat = sample_datetime.isoformat()
 
     # test datetime variable provided as Python datetime
     result = schema.execute(
         """query Test($date: DateTime){ datetime(in: $date) }""",
-        variables={"date": now},
+        variables={"date": sample_datetime},
     )
     assert not result.errors
     assert result.data == {"datetime": isoformat}
@@ -114,13 +125,13 @@ def test_datetime_query_variable(now):
     assert result.data == {"datetime": isoformat}
 
 
-def test_date_query_variable(now):
-    now = now.date()
-    isoformat = now.isoformat()
+def test_date_query_variable(sample_date):
+    isoformat = sample_date.isoformat()
 
     # test date variable provided as Python date
     result = schema.execute(
-        """query Test($date: Date){ date(in: $date) }""", variables={"date": now}
+        """query Test($date: Date){ date(in: $date) }""",
+        variables={"date": sample_date},
     )
     assert not result.errors
     assert result.data == {"date": isoformat}
@@ -133,12 +144,13 @@ def test_date_query_variable(now):
     assert result.data == {"date": isoformat}
 
 
-def test_time_query_variable(time):
-    isoformat = time.isoformat()
+def test_time_query_variable(sample_time):
+    isoformat = sample_time.isoformat()
 
     # test time variable provided as Python time
     result = schema.execute(
-        """query Test($time: Time){ time(at: $time) }""", variables={"time": time}
+        """query Test($time: Time){ time(at: $time) }""",
+        variables={"time": sample_time},
     )
     assert not result.errors
     assert result.data == {"time": isoformat}
@@ -154,11 +166,13 @@ def test_time_query_variable(time):
 @pytest.mark.xfail(
     reason="creating the error message fails when un-parsable object is not JSON serializable."
 )
-def test_bad_variables():
-    def _test_bad_variables(type, input):
+def test_bad_variables(sample_date, sample_datetime, sample_time):
+    def _test_bad_variables(type_, input_):
         result = schema.execute(
-            """query Test($input: {}){{ {}(in: $input) }}""".format(type, type.lower()),
-            variables={"input": input},
+            """query Test($input: {}){{ {}(in: $input) }}""".format(
+                type_, type_.lower()
+            ),
+            variables={"input": input_},
         )
         assert len(result.errors) == 1
         # when `input` is not JSON serializable formatting the error message in
@@ -169,9 +183,9 @@ def test_bad_variables():
 
     not_a_date = dict()
     not_a_date_str = "Some string that's not a date"
-    today = datetime.date.today()
-    now = datetime.datetime.now().replace(tzinfo=pytz.utc)
-    time = datetime.time(now.hour, now.minute, now.second, now.microsecond, now.tzinfo)
+    today = sample_date
+    now = sample_datetime
+    time = sample_time
 
     bad_pairs = [
         ("DateTime", not_a_date),
@@ -188,5 +202,5 @@ def test_bad_variables():
         ("Time", today),
     ]
 
-    for type, input in bad_pairs:
-        _test_bad_variables(type, input)
+    for type_, input_ in bad_pairs:
+        _test_bad_variables(type_, input_)

--- a/graphene/types/tests/test_datetime.py
+++ b/graphene/types/tests/test_datetime.py
@@ -27,8 +27,19 @@ class Query(ObjectType):
 schema = Schema(query=Query)
 
 
-def test_datetime_query():
-    now = datetime.datetime.now().replace(tzinfo=pytz.utc)
+@pytest.fixture
+def now():
+    utc_datetime = datetime.datetime(2019, 5, 25, 5, 30, 15, 10, pytz.utc)
+    return utc_datetime
+
+
+@pytest.fixture
+def time(now):
+    time = datetime.time(now.hour, now.minute, now.second, now.microsecond, now.tzinfo)
+    return time
+
+
+def test_datetime_query(now):
     isoformat = now.isoformat()
 
     result = schema.execute("""{ datetime(in: "%s") }""" % isoformat)
@@ -36,8 +47,8 @@ def test_datetime_query():
     assert result.data == {"datetime": isoformat}
 
 
-def test_date_query():
-    now = datetime.datetime.now().replace(tzinfo=pytz.utc).date()
+def test_date_query(now):
+    now = now.date()
     isoformat = now.isoformat()
 
     result = schema.execute("""{ date(in: "%s") }""" % isoformat)
@@ -45,9 +56,7 @@ def test_date_query():
     assert result.data == {"date": isoformat}
 
 
-def test_time_query():
-    now = datetime.datetime.now().replace(tzinfo=pytz.utc)
-    time = datetime.time(now.hour, now.minute, now.second, now.microsecond, now.tzinfo)
+def test_time_query(time):
     isoformat = time.isoformat()
 
     result = schema.execute("""{ time(at: "%s") }""" % isoformat)
@@ -85,8 +94,7 @@ def test_bad_time_query():
     assert result.data is None
 
 
-def test_datetime_query_variable():
-    now = datetime.datetime.now().replace(tzinfo=pytz.utc)
+def test_datetime_query_variable(now):
     isoformat = now.isoformat()
 
     # test datetime variable provided as Python datetime
@@ -106,8 +114,8 @@ def test_datetime_query_variable():
     assert result.data == {"datetime": isoformat}
 
 
-def test_date_query_variable():
-    now = datetime.datetime.now().replace(tzinfo=pytz.utc).date()
+def test_date_query_variable(now):
+    now = now.date()
     isoformat = now.isoformat()
 
     # test date variable provided as Python date
@@ -125,9 +133,7 @@ def test_date_query_variable():
     assert result.data == {"date": isoformat}
 
 
-def test_time_query_variable():
-    now = datetime.datetime.now().replace(tzinfo=pytz.utc)
-    time = datetime.time(now.hour, now.minute, now.second, now.microsecond, now.tzinfo)
+def test_time_query_variable(time):
     isoformat = time.isoformat()
 
     # test time variable provided as Python time


### PR DESCRIPTION
Always use fixed values for tests to avoid flaky results in CI.