### PR TITLE
updating codeowners to have additional reviewers for docs and examples

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,3 @@
 / @syrusakbary @ekampf @dan98765 @projectcheshire
+/docs/ @dvndrsn @phalt @changeling
+/examples/ @dvndrsn @phalt @changeling


### PR DESCRIPTION
Adds @dvndrsn @phalt @changeling as CODEOWNERS for /docs/ and /examples/ changes so they can update/review/approve documentation changes.