### PR TITLE
updating codeowners to have additional reviewers for docs and example…

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,3 @@
 / @syrusakbary @ekampf @dan98765 @projectcheshire
+/docs/ @dvndrsn @phalt @changeling
+/examples/ @dvndrsn @phalt @changeling


### PR DESCRIPTION
… changes

Updating `next/master` `CODEOWNERS` to match `master`