### PR TITLE
Fix malformed version on aniso8601 requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,7 @@ setup(
         "six>=1.10.0,<2",
         "graphql-core>=2.1,<3",
         "graphql-relay>=0.4.5,<1",
-        "aniso8601>=3,<=6.0",
+        "aniso8601>=3,<=6",
     ],
     tests_require=tests_require,
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,7 @@ setup(
         "six>=1.10.0,<2",
         "graphql-core>=2.1,<3",
         "graphql-relay>=0.4.5,<1",
-        "aniso8601>=3,<=6.0.*",
+        "aniso8601>=3,<=6.0",
     ],
     tests_require=tests_require,
     extras_require={


### PR DESCRIPTION
This was changed on https://github.com/graphql-python/graphene/pull/935 to fix a warning when installing newer versions but we are now getting an error that 6.0.0 doesn't match 6.0.*:
 ```
ERROR: graphene 2.1.5 has requirement aniso8601<=6.0.*,>=3, but you'll have aniso8601 6.0.0 which is incompatible.
```
I don't think that the `*` are recognized as the same version.