### PR TITLE
Add interfaces meta argument on Mutations

### DIFF
--- a/graphene/types/objecttype.py
+++ b/graphene/types/objecttype.py
@@ -121,7 +121,8 @@ class ObjectType(BaseType):
         else:
             _meta.fields = fields
 
-        _meta.interfaces = interfaces
+        if not _meta.interfaces:
+            _meta.interfaces = interfaces
         _meta.possible_types = possible_types
         _meta.default_resolver = default_resolver
 

--- a/graphene/types/tests/test_mutation.py
+++ b/graphene/types/tests/test_mutation.py
@@ -7,6 +7,11 @@ from ..objecttype import ObjectType
 from ..scalars import String
 from ..schema import Schema
 from ..structures import NonNull
+from ..interface import Interface
+
+
+class MyType(Interface):
+    pass
 
 
 def test_generate_mutation_no_args():
@@ -28,12 +33,14 @@ def test_generate_mutation_with_meta():
         class Meta:
             name = "MyOtherMutation"
             description = "Documentation"
+            interfaces = (MyType,)
 
         def mutate(self, info, **args):
             return args
 
     assert MyMutation._meta.name == "MyOtherMutation"
     assert MyMutation._meta.description == "Documentation"
+    assert MyMutation._meta.interfaces == (MyType,)
     resolved = MyMutation.Field().resolver(None, None, name="Peter")
     assert resolved == {"name": "Peter"}
 


### PR DESCRIPTION
Allow mutations to apply the `interfaces` META argument to have the payload object type implement the desired interfaces.

Fixes #994