### PR TITLE
Upgrade graphql-relay

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ python:
   - "3.5"
   - "3.6"
   - "3.7"
-  - "pypy3"
 
 install:
   - pip install tox tox-travis

--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,7 @@ setup(
     install_requires=[
         "six>=1.10.0,<2",
         "graphql-core>=2.1,<3",
-        "graphql-relay>=0.4.5,<1",
+        "graphql-relay>=2,<3",
         "aniso8601>=3,<=6",
     ],
     tests_require=tests_require,


### PR DESCRIPTION
Graphql-relay was recently released with a restriction on graphql-core=<2. However graphene relies on graphql-core>=2,<3 which is causing issues: https://github.com/graphql-python/graphql-relay-py/issues/23
https://github.com/graphql-python/graphene/issues/1031