### PR TITLE
Propagate arguments of relay.NodeField to Field

### DIFF
--- a/graphene/relay/node.py
+++ b/graphene/relay/node.py
@@ -57,6 +57,8 @@ class NodeField(Field):
             # If we don's specify a type, the field type will be the node
             # interface
             type or node,
+            name=name,
+            deprecation_reason=deprecation_reason,
             description="The ID of the object",
             id=ID(required=True),
         )

--- a/graphene/relay/node.py
+++ b/graphene/relay/node.py
@@ -48,7 +48,15 @@ class GlobalID(Field):
 
 
 class NodeField(Field):
-    def __init__(self, node, type=False, deprecation_reason=None, name=None, **kwargs):
+    def __init__(
+        self,
+        node,
+        type=False,
+        deprecation_reason=None,
+        name=None,
+        description=None,
+        **kwargs
+    ):
         assert issubclass(node, Node), "NodeField can only operate in Nodes"
         self.node_type = node
         self.field_type = type
@@ -58,9 +66,9 @@ class NodeField(Field):
             # interface
             type or node,
             name=name,
+            description=description,
             deprecation_reason=deprecation_reason,
-            description="The ID of the object",
-            id=ID(required=True),
+            id=ID(required=True, description="The ID of the object"),
         )
 
     def get_resolver(self, parent_resolver):

--- a/graphene/relay/node.py
+++ b/graphene/relay/node.py
@@ -48,15 +48,7 @@ class GlobalID(Field):
 
 
 class NodeField(Field):
-    def __init__(
-        self,
-        node,
-        type=False,
-        deprecation_reason=None,
-        name=None,
-        description=None,
-        **kwargs
-    ):
+    def __init__(self, node, type=False, **kwargs):
         assert issubclass(node, Node), "NodeField can only operate in Nodes"
         self.node_type = node
         self.field_type = type
@@ -65,10 +57,8 @@ class NodeField(Field):
             # If we don's specify a type, the field type will be the node
             # interface
             type or node,
-            name=name,
-            description=description,
-            deprecation_reason=deprecation_reason,
             id=ID(required=True, description="The ID of the object"),
+            **kwargs
         )
 
     def get_resolver(self, parent_resolver):

--- a/graphene/relay/tests/test_node.py
+++ b/graphene/relay/tests/test_node.py
@@ -110,6 +110,12 @@ def test_node_field_custom():
     assert node_field.node_type == Node
 
 
+def test_node_field_custom_name():
+    name = "my_named_node"
+    named_node_field = Node.Field(name=name)
+    assert named_node_field.name == name
+
+
 def test_node_field_only_type():
     executed = schema.execute(
         '{ onlyNode(id:"%s") { __typename, name } } ' % Node.to_global_id("MyNode", 1)

--- a/graphene/relay/tests/test_node.py
+++ b/graphene/relay/tests/test_node.py
@@ -114,7 +114,7 @@ def test_node_field_args():
     field_args = {
         "name": "my_custom_name",
         "description": "my_custom_description",
-        "deprecation_reason": "my_custom_deprecation_reason"
+        "deprecation_reason": "my_custom_deprecation_reason",
     }
     node_field = Node.Field(**field_args)
     for field_arg, value in field_args.items():

--- a/graphene/relay/tests/test_node.py
+++ b/graphene/relay/tests/test_node.py
@@ -110,10 +110,15 @@ def test_node_field_custom():
     assert node_field.node_type == Node
 
 
-def test_node_field_custom_name():
-    name = "my_named_node"
-    named_node_field = Node.Field(name=name)
-    assert named_node_field.name == name
+def test_node_field_args():
+    field_args = {
+        "name": "my_custom_name",
+        "description": "my_custom_description",
+        "deprecation_reason": "my_custom_deprecation_reason"
+    }
+    node_field = Node.Field(**field_args)
+    for field_arg, value in field_args.items():
+        assert getattr(node_field, field_arg) == value
 
 
 def test_node_field_only_type():


### PR DESCRIPTION
Closes #1035 

Question: Should all `**kwargs` from `NodeField`'s constructor be propagated or should there be any check to ensure the field gets no arguments other than `id`?

Edit 1: I also moved the "The ID of the object" description to the ID argument instead of the whole Field, since it seemed more appropriate, and included `description` in the propagated arguments.