### PR TITLE
Allow bumped version of aniso8601

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,7 @@ setup(
         "six>=1.10.0,<2",
         "graphql-core>=2.1,<3",
         "graphql-relay>=2,<3",
-        "aniso8601>=3,<=6",
+        "aniso8601>=3,<=7",
     ],
     tests_require=tests_require,
     extras_require={


### PR DESCRIPTION
In version 6 aniso8601 some rounding bugs were introduced. 
See the issue reported here: https://bitbucket.org/nielsenb/aniso8601/issues/24/float-induced-rounding-errors-when-parsing
See the commit that fixed it here: https://bitbucket.org/nielsenb/aniso8601/commits/b4aca8ffc25588128d1c463ca735c8d6f180f55a
Allow for a higher version to allow graphene users to avoid these issues.