### PR TITLE
Increase the allowed version of aniso8601

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ setup(
     install_requires=[
         "graphql-core>=3.0.0a0,<4",
         "graphql-relay>=3.0.0a0,<4",
-        "aniso8601>=6,<8",
+        "aniso8601>=6,<9",
     ],
     tests_require=tests_require,
     extras_require={"test": tests_require},


### PR DESCRIPTION
A newer version 8.0.0 of aniso8601 has been released.
The only change doesn't seem to break graphene.
https://bitbucket.org/nielsenb/aniso8601/pull-requests/12/allow-commas-as-decimal-separators-on-time/diff