### PR TITLE
Add a helpful message to when a global_id fails to parse.

### DIFF
--- a/graphene/relay/node.py
+++ b/graphene/relay/node.py
@@ -1,4 +1,3 @@
-from collections import OrderedDict
 from functools import partial
 from inspect import isclass
 
@@ -62,14 +61,7 @@ class NodeField(Field):
         )
 
     def get_resolver(self, parent_resolver):
-        def return_partial(*args, **kwargs):
-            print("\n\nDebugging get_resolver: ")
-            print(parent_resolver, args, kwargs)
-            return partial(self.node_type.node_resolver, get_type(self.field_type))(
-                *args, **kwargs
-            )
-
-        return return_partial
+        return partial(self.node_type.node_resolver, get_type(self.field_type))
 
 
 class AbstractNode(Interface):
@@ -79,9 +71,7 @@ class AbstractNode(Interface):
     @classmethod
     def __init_subclass_with_meta__(cls, **options):
         _meta = InterfaceOptions(cls)
-        _meta.fields = OrderedDict(
-            id=GlobalID(cls, description="The ID of the object.")
-        )
+        _meta.fields = {"id": GlobalID(cls, description="The ID of the object")}
         super(AbstractNode, cls).__init_subclass_with_meta__(_meta=_meta, **options)
 
 
@@ -102,8 +92,11 @@ class Node(AbstractNode):
             _type, _id = cls.from_global_id(global_id)
             graphene_type = info.schema.get_type(_type).graphene_type
         except Exception as e:
-            print(e)
-            raise
+            raise Exception(
+                "Unable call from_global_id, is the id base64 encoding of 'TypeName:id': {} Exception: {}".format(
+                    str(global_id), str(e)
+                )
+            )
         if only_type:
             assert graphene_type == only_type, ("Must receive a {} id.").format(
                 only_type._meta.name

--- a/graphene/relay/node.py
+++ b/graphene/relay/node.py
@@ -93,7 +93,7 @@ class Node(AbstractNode):
             graphene_type = info.schema.get_type(_type).graphene_type
         except Exception as e:
             raise Exception(
-                "Unable call from_global_id, is the id base64 encoding of 'TypeName:id': {} Exception: {}".format(
+                "Unable to call from_global_id, is the id a base64 encoding of 'TypeName:id': {} Exception: {}".format(
                     str(global_id), str(e)
                 )
             )

--- a/graphene/relay/node.py
+++ b/graphene/relay/node.py
@@ -91,9 +91,13 @@ class Node(AbstractNode):
         try:
             _type, _id = cls.from_global_id(global_id)
             graphene_type = info.schema.get_type(_type).graphene_type
-        except Exception:
-            return None
-
+        except Exception as e:
+            raise Exception(
+                "Unable call from_global_id, is the id base64 encoding of 'TypeName:id': {} Exception: {}".format(
+                    str(global_id),
+                    str(e)
+                )
+            )
         if only_type:
             assert graphene_type == only_type, ("Must receive a {} id.").format(
                 only_type._meta.name

--- a/graphene/relay/node.py
+++ b/graphene/relay/node.py
@@ -90,13 +90,25 @@ class Node(AbstractNode):
     def get_node_from_global_id(cls, info, global_id, only_type=None):
         try:
             _type, _id = cls.from_global_id(global_id)
-            graphene_type = info.schema.get_type(_type).graphene_type
         except Exception as e:
             raise Exception(
-                "Unable to call from_global_id, is the id a base64 encoding of 'TypeName:id': {} Exception: {}".format(
-                    str(global_id), str(e)
+                (
+                    'Unable to parse global ID "{global_id}". '
+                    'Make sure it is a base64 encoded string in the format: "TypeName:id". '
+                    "Exception message: {exception}".format(
+                        global_id=global_id, exception=str(e)
+                    )
                 )
             )
+
+        graphene_type = info.schema.get_type(_type)
+        if graphene_type is None:
+            raise Exception(
+                'Relay Node "{_type}" not found in schema'.format(_type=_type)
+            )
+
+        graphene_type = graphene_type.graphene_type
+
         if only_type:
             assert graphene_type == only_type, ("Must receive a {} id.").format(
                 only_type._meta.name
@@ -104,7 +116,11 @@ class Node(AbstractNode):
 
         # We make sure the ObjectType implements the "Node" interface
         if cls not in graphene_type._meta.interfaces:
-            return None
+            raise Exception(
+                'ObjectType "{_type}" does not implement the "{cls}" interface.'.format(
+                    _type=_type, cls=cls
+                )
+            )
 
         get_node = getattr(graphene_type, "get_node", None)
         if get_node:

--- a/graphene/relay/tests/test_node.py
+++ b/graphene/relay/tests/test_node.py
@@ -90,7 +90,7 @@ def test_node_query_incorrect_id():
     executed = schema.execute(
         '{ node(id:"%s") { ... on MyNode { name } } }' % "something:2"
     )
-    assert not executed.errors
+    assert executed.errors
     assert executed.data == {"node": None}
 
 

--- a/graphene/relay/tests/test_node.py
+++ b/graphene/relay/tests/test_node.py
@@ -1,3 +1,4 @@
+import re
 from graphql_relay import to_global_id
 
 from graphql.pyutils import dedent
@@ -83,6 +84,20 @@ def test_node_requesting_non_node():
     executed = schema.execute(
         '{ node(id:"%s") { __typename } } ' % Node.to_global_id("RootQuery", 1)
     )
+    assert executed.errors
+    assert re.match(
+        r"ObjectType .* does not implement the .* interface.",
+        executed.errors[0].message,
+    )
+    assert executed.data == {"node": None}
+
+
+def test_node_requesting_unknown_type():
+    executed = schema.execute(
+        '{ node(id:"%s") { __typename } } ' % Node.to_global_id("UnknownType", 1)
+    )
+    assert executed.errors
+    assert re.match(r"Relay Node .* not found in schema", executed.errors[0].message)
     assert executed.data == {"node": None}
 
 
@@ -91,6 +106,7 @@ def test_node_query_incorrect_id():
         '{ node(id:"%s") { ... on MyNode { name } } }' % "something:2"
     )
     assert executed.errors
+    assert re.match(r"Unable to parse global ID .*", executed.errors[0].message)
     assert executed.data == {"node": None}
 
 


### PR DESCRIPTION
It was really difficult to determine that I wasn't using the correct format for an ID.

It was previously returning null, it now returns an error.message with `Incorrect Padding` and displays the exception traceback inside the server logs.

I'm not sure about whether `return None` is/was intended functionality.

I do see some of the tests are failing:

```
_________________________ test_node_query_incorrect_id _________________________
    def test_node_query_incorrect_id():
        executed = schema.execute(
            '{ node(id:"%s") { ... on MyNode { name } } }' % "something:2"
        )
>       assert not executed.errors

E       assert not [GraphQLError("Unable call from_global_id, is the id base64 encoding of 'TypeName:id': something:2 Exception: Incorrect padding", 
locations=[SourceLocation(line=1, column=3)], path=['node'])]

E        +  where [GraphQLError("Unable call from_global_id, is the id base64 encoding of 'TypeName:id': something:2 Exception: Incorrect padding", 
locations=[SourceLocation(line=1, column=3)], path=['node'])] = 
ExecutionResult(data={'node': None}, 
errors=[GraphQLError("Unable call from_global_id, is the id base64 encoding of 'TypeName:id': something:2 Exception: Incorrect padding", 
locations=[SourceLocation(line=1, column=3)], 
path=['node'])]).errors
```

edit: test updated.