### PR TITLE
Fix argument list in middleware docs

### DIFF
--- a/docs/execution/middleware.rst
+++ b/docs/execution/middleware.rst
@@ -29,7 +29,7 @@ This middleware only continues evaluation if the ``field_name`` is not ``'user'`
 .. code:: python
 
     class AuthorizationMiddleware(object):
-        def resolve(next, root, info, **args):
+        def resolve(self, next, root, info, **args):
             if info.field_name == 'user':
                 return None
             return next(root, info, **args)


### PR DESCRIPTION
Using the literal example for AuthorizationMiddleware leads to the following error:

`graphql.error.located_error.GraphQLLocatedError: resolve() takes 3 positional arguments but 4 were given`

If `AuthorizationMiddleware` is to be instantiated, it should receive `self` as the first argument.