### PR TITLE
The default_value of InputField should be INVALID

### DIFF
--- a/examples/starwars_relay/tests/snapshots/snap_test_objectidentification.py
+++ b/examples/starwars_relay/tests/snapshots/snap_test_objectidentification.py
@@ -46,7 +46,7 @@ type Faction implements Node {
 input IntroduceShipInput {
   shipName: String!
   factionId: String!
-  clientMutationId: String = null
+  clientMutationId: String
 }
 
 type IntroduceShipPayload {

--- a/graphene/relay/tests/test_mutation.py
+++ b/graphene/relay/tests/test_mutation.py
@@ -80,11 +80,11 @@ class OtherMutation(ClientIDMutation):
 
     @staticmethod
     def mutate_and_get_payload(
-        self, info, shared, additional_field, client_mutation_id=None
+        self, info, shared="", additional_field="", client_mutation_id=None
     ):
         edge_type = MyEdge
         return OtherMutation(
-            name=(shared or "") + (additional_field or ""),
+            name=shared + additional_field,
             my_node_edge=edge_type(cursor="1", node=MyNode(name="name")),
         )
 

--- a/graphene/types/inputfield.py
+++ b/graphene/types/inputfield.py
@@ -1,4 +1,4 @@
-from graphql.error import INVALID
+from graphql import Undefined
 from .mountedtype import MountedType
 from .structures import NonNull
 from .utils import get_type
@@ -49,7 +49,7 @@ class InputField(MountedType):
         self,
         type,
         name=None,
-        default_value=INVALID,
+        default_value=Undefined,
         deprecation_reason=None,
         description=None,
         required=False,

--- a/graphene/types/inputfield.py
+++ b/graphene/types/inputfield.py
@@ -1,3 +1,4 @@
+from graphql.error import INVALID
 from .mountedtype import MountedType
 from .structures import NonNull
 from .utils import get_type
@@ -48,7 +49,7 @@ class InputField(MountedType):
         self,
         type,
         name=None,
-        default_value=None,
+        default_value=INVALID,
         deprecation_reason=None,
         description=None,
         required=False,

--- a/graphene/types/tests/test_query.py
+++ b/graphene/types/tests/test_query.py
@@ -262,17 +262,14 @@ def test_query_input_field():
 
     result = test_schema.execute('{ test(aInput: {aField: "String!"} ) }', "Source!")
     assert not result.errors
-    assert result.data == {
-        "test": '["Source!",{"a_input":{"a_field":"String!","recursive_field":null}}]'
-    }
+    assert result.data == {"test": '["Source!",{"a_input":{"a_field":"String!"}}]'}
 
     result = test_schema.execute(
         '{ test(aInput: {recursiveField: {aField: "String!"}}) }', "Source!"
     )
     assert not result.errors
     assert result.data == {
-        "test": '["Source!",{"a_input":{"a_field":null,"recursive_field":'
-        '{"a_field":"String!","recursive_field":null}}}]'
+        "test": '["Source!",{"a_input":{"recursive_field":{"a_field":"String!"}}}]'
     }
 
 
@@ -408,7 +405,7 @@ def test_big_list_of_containers_multiple_fields_query_benchmark(benchmark):
 
 
 def test_big_list_of_containers_multiple_fields_custom_resolvers_query_benchmark(
-    benchmark
+    benchmark,
 ):
     class Container(ObjectType):
         x = Int()

--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,7 @@ setup(
     keywords="api graphql protocol rest relay graphene",
     packages=find_packages(exclude=["tests", "tests.*", "examples"]),
     install_requires=[
-        "graphql-core>=3.0.0,<4",
+        "graphql-core>=3.0.3,<4",
         "graphql-relay>=3.0.0,<4",
         "aniso8601>=6,<9",
     ],

--- a/tests_asyncio/test_relay_mutation.py
+++ b/tests_asyncio/test_relay_mutation.py
@@ -42,11 +42,11 @@ class OtherMutation(ClientIDMutation):
 
     @staticmethod
     def mutate_and_get_payload(
-        self, info, shared, additional_field, client_mutation_id=None
+        self, info, shared="", additional_field="", client_mutation_id=None
     ):
         edge_type = MyEdge
         return OtherMutation(
-            name=(shared or "") + (additional_field or ""),
+            name=shared + additional_field,
             my_node_edge=edge_type(cursor="1", node=MyNode(name="name")),
         )
 


### PR DESCRIPTION
Since GraphQL 3.0 there is a distinction between None and INVALID (no value).
The tests captured the bug and are updated.

See also https://github.com/graphql-python/graphql-core-next/pull/66#issuecomment-557688621

I think there are more bugs of this kind, but since I don't know graphene well, yet, I take baby steps.

I could not track the snapshot differences, the order is wrong and master has the same problem too. If master is solved I'll rebase this PR. @jkimbo has the same differences in his commits.