### PR TITLE
Fix typo in execute.rst

### DIFF
--- a/docs/execution/execute.rst
+++ b/docs/execution/execute.rst
@@ -4,7 +4,7 @@ Executing a query
 =================
 
 
-For executing a query a schema, you can directly call the ``execute`` method on it.
+For executing a query against a schema, you can directly call the ``execute`` method on it.
 
 
 .. code:: python


### PR DESCRIPTION
`a query a schema` should be `a query against a schema`