### PR TITLE
fix typo in class 'Interface'

### DIFF
--- a/graphene/types/interface.py
+++ b/graphene/types/interface.py
@@ -68,4 +68,4 @@ class Interface(BaseType):
             return type(instance)
 
     def __init__(self, *args, **kwargs):
-        raise Exception("An Interface cannot be intitialized")
+        raise Exception("An Interface cannot be initialized")


### PR DESCRIPTION
Fixed typo in class `Interface`
