### PR TITLE
Fix example query in quickstart doc

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -127,7 +127,7 @@ Then we can start querying our **Schema** by passing a GraphQL query string to `
     query_string = '{ hello }'
     result = schema.execute(query_string)
     print(result.data['hello'])
-    # "Hello stranger"
+    # "Hello stranger!"
 
     # or passing the argument in the query
     query_with_argument = '{ hello(name: "GraphQL") }'


### PR DESCRIPTION
From the "Querying" section of the quickstart doc:
```
# we can query for our field (with the default argument)
query_string = '{ hello }'
result = schema.execute(query_string)
print(result.data['hello'])
# "Hello stranger"

# or passing the argument in the query
query_with_argument = '{ hello(name: "GraphQL") }'
result = schema.execute(query_with_argument)
print(result.data['hello'])
# "Hello GraphQL!"
```
(https://docs.graphene-python.org/en/latest/quickstart/#querying)

"Hello stranger" should also end with a `!`