### PR TITLE
Use default_resolver to resolve values when using the source attribute

### DIFF
--- a/graphene/types/field.py
+++ b/graphene/types/field.py
@@ -4,6 +4,7 @@ from functools import partial
 
 from .argument import Argument, to_arguments
 from .mountedtype import MountedType
+from .resolver import default_resolver
 from .structures import NonNull
 from .unmountedtype import UnmountedType
 from .utils import get_type
@@ -12,7 +13,7 @@ base_type = type
 
 
 def source_resolver(source, root, info, **args):
-    resolved = getattr(root, source, None)
+    resolved = default_resolver(source, None, root, info, **args)
     if inspect.isfunction(resolved) or inspect.ismethod(resolved):
         return resolved()
     return resolved

--- a/graphene/types/tests/test_field.py
+++ b/graphene/types/tests/test_field.py
@@ -66,6 +66,13 @@ def test_field_source():
     assert field.resolver(MyInstance(), None) == MyInstance.value
 
 
+def test_field_source_dict_or_attr():
+    MyType = object()
+    field = Field(MyType, source="value")
+    assert field.resolver(MyInstance(), None) == MyInstance.value
+    assert field.resolver({"value": MyInstance.value}, None) == MyInstance.value
+
+
 def test_field_with_lazy_type():
     MyType = object()
     field = Field(lambda: MyType)


### PR DESCRIPTION
This PR fixes a bug where if you were using the `source` attribute on a field (https://docs.graphene-python.org/en/stable/api/#fields-mounted-types) it wouldn't work if the root value was a dictionary. The fix is to change the code to use use the `default_resolver` method which accepts both objects and dictionaries.