### PR TITLE
Set any arbitrary meta fields onto the meta instance

### DIFF
--- a/graphene/types/base.py
+++ b/graphene/types/base.py
@@ -40,6 +40,11 @@ class BaseType(SubclassWithMeta):
             return
         _meta.name = name or cls.__name__
         _meta.description = description or trim_docstring(cls.__doc__)
+
+        # Set all extra arguments onto the meta class as well
+        for key, value in _kwargs.items():
+            setattr(_meta, key, value)
+
         _meta.freeze()
         cls._meta = _meta
         super(BaseType, cls).__init_subclass_with_meta__()

--- a/graphene/types/tests/test_objecttype.py
+++ b/graphene/types/tests/test_objecttype.py
@@ -275,3 +275,12 @@ def test_objecttype_meta_with_annotations():
 
     schema = Schema(query=Query)
     assert schema is not None
+
+
+def test_objecttype_meta_extra_fields():
+    class Query(ObjectType):
+        class Meta:
+            name = "MyQuery"
+            foo = "bar"
+
+    assert Query._meta.foo == "bar"


### PR DESCRIPTION
Following on from https://github.com/graphql-python/graphene/pull/1007

This PR sets all extra `Meta` class fields on the `_meta` instance. Currently any extra fields on the `Meta` class are lost. This PR keeps them around so that they can be used by application code.

Examples of why this is useful:

1. If you wanted to create some custom checks that all DjangoObjectTypes are using the `fields` meta option it's not currently possible. After this PR you could create this function:

```python
def enforce_only_fields(schema):
	types = schema.get_type_map()
	for _, t in types.items():
		if issubclass(t.graphene_type, DjangoObjectType):
			assert t.graphene_type._meta.fields
```

2. You could implement field level permissions in Graphene Django by setting a default resolver and defining some kind of auth configuration like this:


```python
    def authed_resolver(attrname, default_value, root, info, **args):
        auth_map = info.parent_type.graphene_type._meta.auth 
        if attrname in auth_map:
            perm_checks = auth_map[attrname]
            checks = [check(root, info) for check in perm_checks]
            if not all(checks):
                return None
        return graphene.types.resolver.default_resolver(
            attrname, default_value, root, info, **args
        )

    def staff_required(obj, info):
		if not info.context.user.is_staff:
			return False
        return True

    class AuthedType(DjangoObjectType):
        email = graphene.String()

        class Meta:
            model = Reporter
            default_resolver = authed_resolver
            auth = {
				"email": [staff_required]
			}
```