### PR TITLE
added graphene import to READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ pip install "graphene>=2.0"
 Here is one example for you to get started:
 
 ```python
+import graphene
+
 class Query(graphene.ObjectType):
     hello = graphene.String(description='A typical hello world')
 

--- a/README.rst
+++ b/README.rst
@@ -67,6 +67,8 @@ Here is one example for you to get started:
 
 .. code:: python
 
+    import graphene
+
     class Query(graphene.ObjectType):
         hello = graphene.String(description='A typical hello world')
 


### PR DESCRIPTION
It's nice to just be able to copy/paste the entire example without
having to remember the import (aka I'm lazy).