### PR TITLE
Update excluded packages list to properly exclude examples package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ setup(
         "Programming Language :: Python :: 3.8",
     ],
     keywords="api graphql protocol rest relay graphene",
-    packages=find_packages(exclude=["tests", "tests.*", "examples"]),
+    packages=find_packages(exclude=["tests", "tests.*", "examples*"]),
     install_requires=[
         "graphql-core>=3.1.0b1,<4",
         "graphql-relay>=3.0,<4",


### PR DESCRIPTION
As #1110 correctly states, currently `examples` package is installed alongside `graphene` which is probably not intended as `"examples"` is listed in `packages=find_packages(exclude=[...])` list.

I was able to fix it by changing examples in:
`packages=find_packages(exclude=["tests", "tests.*", "examples"])`
 to examples*:
`packages=find_packages(exclude=["tests", "tests.*", "examples*"])`

Unfortunately there seems to be no easy way to make package examples an optional dependency when it is in the same repository. Maybe it will be a good idea to separate examples from main package and then it could be added as extras_require={"examples": ["graphene-examples"]}?

Is it even necessary to allow installation of examples or are they here only for documentation purposes?

_Additional question:_
I am also not sure what `"tests"` in exclude is supposed to do as all test files are currently also included in package installation.