### PR TITLE
Remove @staticmethod decorator in mutations doc

### DIFF
--- a/docs/types/mutations.rst
+++ b/docs/types/mutations.rst
@@ -104,7 +104,6 @@ To use an InputField you define an InputObjectType that specifies the structure 
 
         person = graphene.Field(Person)
 
-        @staticmethod
         def mutate(root, info, person_data=None):
             person = Person(
                 name=person_data.name,


### PR DESCRIPTION
Fixes #1205

The staticmethod decorator is causing confusion and it should at least be consistent in the documentation. 