### PR TITLE
Revert 1213 update mutation docs

### DIFF
--- a/docs/types/mutations.rst
+++ b/docs/types/mutations.rst
@@ -48,7 +48,11 @@ So, we can finish our schema like this:
     class MyMutations(graphene.ObjectType):
         create_person = CreatePerson.Field()
 
-    schema = graphene.Schema(mutation=MyMutations)
+    # We must define a query for our schema
+    class Query(graphene.ObjectType):
+        person = graphene.Field(Person)
+
+    schema = graphene.Schema(query=Query, mutation=MyMutations)
 
 Executing the Mutation
 ----------------------

--- a/graphene/types/schema.py
+++ b/graphene/types/schema.py
@@ -381,7 +381,7 @@ class Schema:
     questions about the types through introspection.
 
     Args:
-        query (Optional[Type[ObjectType]]): Root query *ObjectType*. Describes entry point for fields to *read*
+        query (Type[ObjectType]): Root query *ObjectType*. Describes entry point for fields to *read*
             data in your Schema.
         mutation (Optional[Type[ObjectType]]): Root mutation *ObjectType*. Describes entry point for
             fields to *create, update or delete* data in your API.

--- a/graphene/types/tests/test_schema.py
+++ b/graphene/types/tests/test_schema.py
@@ -59,3 +59,12 @@ def test_schema_str():
 def test_schema_introspect():
     schema = Schema(Query)
     assert "__schema" in schema.introspect()
+
+
+def test_schema_requires_query_type():
+    schema = Schema()
+    result = schema.execute("query {}")
+
+    assert len(result.errors) == 1
+    error = result.errors[0]
+    assert error.message == "Query root type must be provided."


### PR DESCRIPTION
Unfortunately it looks like graphql-core v3 requires a Query root type: https://github.com/graphql-python/graphql-core/blob/ffdf1b3702505cbcfd9fca7d6bde191e7d3f5e47/src/graphql/type/validate.py#L114 (v2 didn't have that check)

This PR reverts graphql-python/graphene#1213 because with the release of Graphene v3 this will no longer be the case. I've also added a test to check the expected behaviour.

FYI @sydoluciani 