### PR TITLE
Rename variables called type to type_

### DIFF
--- a/docs/relay/nodes.rst
+++ b/docs/relay/nodes.rst
@@ -51,20 +51,20 @@ Example of a custom node:
             name = 'Node'
 
         @staticmethod
-        def to_global_id(type, id):
-            return f"{type}:{id}"
+        def to_global_id(type_, id):
+            return f"{type_}:{id}"
 
         @staticmethod
         def get_node_from_global_id(info, global_id, only_type=None):
-            type, id = global_id.split(':')
+            type_, id = global_id.split(':')
             if only_type:
                 # We assure that the node type that we want to retrieve
                 # is the same that was indicated in the field type
-                assert type == only_type._meta.name, 'Received not compatible node.'
+                assert type_ == only_type._meta.name, 'Received not compatible node.'
 
-            if type == 'User':
+            if type_ == 'User':
                 return get_user(id)
-            elif type == 'Photo':
+            elif type_ == 'Photo':
                 return get_photo(id)
 
 

--- a/graphene/pyutils/dataclasses.py
+++ b/graphene/pyutils/dataclasses.py
@@ -845,7 +845,9 @@ def _process_class(cls, init, repr, eq, order, unsafe_hash, frozen):
     # Now find fields in our class.  While doing so, validate some
     # things, and set the default values (as class attributes) where
     # we can.
-    cls_fields = [_get_field(cls, name, type) for name, type in cls_annotations.items()]
+    cls_fields = [
+        _get_field(cls, name, type_) for name, type_ in cls_annotations.items()
+    ]
     for f in cls_fields:
         fields[f.name] = f
 

--- a/graphene/relay/connection.py
+++ b/graphene/relay/connection.py
@@ -117,19 +117,19 @@ def connection_adapter(cls, edges, pageInfo):
 
 
 class IterableConnectionField(Field):
-    def __init__(self, type, *args, **kwargs):
+    def __init__(self, type_, *args, **kwargs):
         kwargs.setdefault("before", String())
         kwargs.setdefault("after", String())
         kwargs.setdefault("first", Int())
         kwargs.setdefault("last", Int())
-        super(IterableConnectionField, self).__init__(type, *args, **kwargs)
+        super(IterableConnectionField, self).__init__(type_, *args, **kwargs)
 
     @property
     def type(self):
-        type = super(IterableConnectionField, self).type
-        connection_type = type
-        if isinstance(type, NonNull):
-            connection_type = type.of_type
+        type_ = super(IterableConnectionField, self).type
+        connection_type = type_
+        if isinstance(type_, NonNull):
+            connection_type = type_.of_type
 
         if is_node(connection_type):
             raise Exception(
@@ -140,7 +140,7 @@ class IterableConnectionField(Field):
         assert issubclass(
             connection_type, Connection
         ), f'{self.__class__.__name__} type has to be a subclass of Connection. Received "{connection_type}".'
-        return type
+        return type_
 
     @classmethod
     def resolve_connection(cls, connection_type, args, resolved):

--- a/graphene/relay/node.py
+++ b/graphene/relay/node.py
@@ -47,15 +47,15 @@ class GlobalID(Field):
 
 
 class NodeField(Field):
-    def __init__(self, node, type=False, **kwargs):
+    def __init__(self, node, type_=False, **kwargs):
         assert issubclass(node, Node), "NodeField can only operate in Nodes"
         self.node_type = node
-        self.field_type = type
+        self.field_type = type_
 
         super(NodeField, self).__init__(
             # If we don's specify a type, the field type will be the node
             # interface
-            type or node,
+            type_ or node,
             id=ID(required=True, description="The ID of the object"),
             **kwargs,
         )
@@ -125,5 +125,5 @@ class Node(AbstractNode):
         return from_global_id(global_id)
 
     @classmethod
-    def to_global_id(cls, type, id):
-        return to_global_id(type, id)
+    def to_global_id(cls, type_, id):
+        return to_global_id(type_, id)

--- a/graphene/relay/tests/test_node_custom.py
+++ b/graphene/relay/tests/test_node_custom.py
@@ -11,7 +11,7 @@ class CustomNode(Node):
         name = "Node"
 
     @staticmethod
-    def to_global_id(type, id):
+    def to_global_id(type_, id):
         return id
 
     @staticmethod

--- a/graphene/types/argument.py
+++ b/graphene/types/argument.py
@@ -40,7 +40,7 @@ class Argument(MountedType):
 
     def __init__(
         self,
-        type,
+        type_,
         default_value=None,
         description=None,
         name=None,
@@ -50,10 +50,10 @@ class Argument(MountedType):
         super(Argument, self).__init__(_creation_counter=_creation_counter)
 
         if required:
-            type = NonNull(type)
+            type_ = NonNull(type_)
 
         self.name = name
-        self._type = type
+        self._type = type_
         self.default_value = default_value
         self.description = description
 

--- a/graphene/types/dynamic.py
+++ b/graphene/types/dynamic.py
@@ -10,10 +10,10 @@ class Dynamic(MountedType):
     the schema. So we can have lazy fields.
     """
 
-    def __init__(self, type, with_schema=False, _creation_counter=None):
+    def __init__(self, type_, with_schema=False, _creation_counter=None):
         super(Dynamic, self).__init__(_creation_counter=_creation_counter)
-        assert inspect.isfunction(type) or isinstance(type, partial)
-        self.type = type
+        assert inspect.isfunction(type_) or isinstance(type_, partial)
+        self.type = type_
         self.with_schema = with_schema
 
     def get_type(self, schema=None):

--- a/graphene/types/field.py
+++ b/graphene/types/field.py
@@ -64,7 +64,7 @@ class Field(MountedType):
 
     def __init__(
         self,
-        type,
+        type_,
         args=None,
         resolver=None,
         source=None,
@@ -88,7 +88,7 @@ class Field(MountedType):
         ), f'The default value can not be a function but received "{base_type(default_value)}".'
 
         if required:
-            type = NonNull(type)
+            type_ = NonNull(type_)
 
         # Check if name is actually an argument of the field
         if isinstance(name, (Argument, UnmountedType)):
@@ -101,7 +101,7 @@ class Field(MountedType):
             source = None
 
         self.name = name
-        self._type = type
+        self._type = type_
         self.args = to_arguments(args or {}, extra_args)
         if source:
             resolver = partial(source_resolver, source)

--- a/graphene/types/inputfield.py
+++ b/graphene/types/inputfield.py
@@ -48,7 +48,7 @@ class InputField(MountedType):
 
     def __init__(
         self,
-        type,
+        type_,
         name=None,
         default_value=Undefined,
         deprecation_reason=None,
@@ -60,8 +60,8 @@ class InputField(MountedType):
         super(InputField, self).__init__(_creation_counter=_creation_counter)
         self.name = name
         if required:
-            type = NonNull(type)
-        self._type = type
+            type_ = NonNull(type_)
+        self._type = type_
         self.deprecation_reason = deprecation_reason
         self.default_value = default_value
         self.description = description

--- a/graphene/types/tests/test_definition.py
+++ b/graphene/types/tests/test_definition.py
@@ -234,10 +234,10 @@ def test_stringifies_simple_types():
 #         (InputObjectType, True)
 #     )
 
-#     for type, answer in expected:
-#         assert is_input_type(type) == answer
-#         assert is_input_type(GraphQLList(type)) == answer
-#         assert is_input_type(GraphQLNonNull(type)) == answer
+#     for type_, answer in expected:
+#         assert is_input_type(type_) == answer
+#         assert is_input_type(GraphQLList(type_)) == answer
+#         assert is_input_type(GraphQLNonNull(type_)) == answer
 
 
 # def test_identifies_output_types():


### PR DESCRIPTION
Co-authored-by: Daniel Gallagher <daniellg@yelp.com>

This is the continuation of #738 . I rebased it on master and replaced `type` with `type_` in some places not covered by the original PR (due to its age).

This PR is related to #1127 and finally fixes #700.