### PR TITLE
Allow adding GraphQL types to Graphene schema

### DIFF
--- a/graphene/types/objecttype.py
+++ b/graphene/types/objecttype.py
@@ -1,3 +1,5 @@
+import inspect
+
 from .base import BaseOptions, BaseType, BaseTypeMeta
 from .field import Field
 from .interface import Interface
@@ -137,7 +139,7 @@ class ObjectType(BaseType, metaclass=ObjectTypeMeta):
         fields = {}
 
         for interface in interfaces:
-            assert issubclass(
+            assert inspect.isclass(interface) and issubclass(
                 interface, Interface
             ), f'All interfaces of {cls.__name__} must be a subclass of Interface. Received "{interface}".'
             fields.update(interface._meta.fields)

--- a/graphene/types/schema.py
+++ b/graphene/types/schema.py
@@ -23,6 +23,7 @@ from graphql import (
     GraphQLObjectType,
     GraphQLSchema,
     GraphQLString,
+    GraphQLType,
     Undefined,
 )
 
@@ -106,6 +107,11 @@ class TypeMap(dict):
     def add_type(self, graphene_type):
         if inspect.isfunction(graphene_type):
             graphene_type = graphene_type()
+
+        # If type is a GraphQLType from graphql-core then return it immediately
+        if isinstance(graphene_type, GraphQLType):
+            return graphene_type
+
         if isinstance(graphene_type, List):
             return GraphQLList(self.add_type(graphene_type.of_type))
         if isinstance(graphene_type, NonNull):

--- a/graphene/types/schema.py
+++ b/graphene/types/schema.py
@@ -258,7 +258,8 @@ class TypeMap(dict):
             union_types = []
             for graphene_objecttype in graphene_type._meta.types:
                 object_type = create_graphql_type(graphene_objecttype)
-                assert object_type.graphene_type == graphene_objecttype
+                if hasattr(object_type, "graphene_type"):
+                    assert object_type.graphene_type == graphene_objecttype
                 union_types.append(object_type)
             return union_types
 


### PR DESCRIPTION
This PR allows adding plain GraphQL types to a Graphene schema. This opens up the option for other libraries to interop with Graphene.