### PR TITLE
Split out the subscriptions documentation a separate file and fix it

### DIFF
--- a/docs/execution/execute.rst
+++ b/docs/execution/execute.rst
@@ -3,7 +3,6 @@
 Executing a query
 =================
 
-
 For executing a query against a schema, you can directly call the ``execute`` method on it.
 
 
@@ -16,43 +15,6 @@ For executing a query against a schema, you can directly call the ``execute`` me
 
 ``result`` represents the result of execution. ``result.data`` is the result of executing the query, ``result.errors`` is ``None`` if no errors occurred, and is a non-empty list if an error occurred.
 
-
-For executing a subscription, you can directly call the ``subscribe`` method on it.
-This method is async and must be awaited.
-
-.. code:: python
-
-    import asyncio
-    from datetime import datetime
-    from graphene import ObjectType, String, Schema, Field
-
-    # All schema require a query.
-    class Query(ObjectType):
-        hello = String()
-
-        def resolve_hello(root, info):
-            return 'Hello, world!'
-
-    class Subscription(ObjectType):
-        time_of_day = Field(String)
-
-        async def subscribe_time_of_day(root, info):
-            while True:
-                yield { 'time_of_day': datetime.now().isoformat()}
-                await asyncio.sleep(1)
-
-    SCHEMA = Schema(query=Query, subscription=Subscription)
-
-    async def main(schema):
-
-        subscription = 'subscription { timeOfDay }'
-        result = await schema.subscribe(subscription)
-        async for item in result:
-            print(item.data['timeOfDay'])
-
-    asyncio.run(main(SCHEMA))
-
-The ``result`` is an async iterator which yields items in the same manner as a query.
 
 .. _SchemaExecuteContext:
 

--- a/docs/execution/index.rst
+++ b/docs/execution/index.rst
@@ -9,3 +9,4 @@ Execution
    middleware
    dataloader
    fileuploading
+   subscriptions

--- a/docs/execution/subscriptions.rst
+++ b/docs/execution/subscriptions.rst
@@ -1,0 +1,40 @@
+.. _SchemaSubscription:
+
+Subscriptions
+=============
+
+To create a subscription, you can directly call the ``subscribe`` method on the
+schema. This method is async and must be awaited.
+
+.. code:: python
+
+    import asyncio
+    from datetime import datetime
+    from graphene import ObjectType, String, Schema, Field
+
+    # Every schema requires a query.
+    class Query(ObjectType):
+        hello = String()
+
+        def resolve_hello(root, info):
+            return "Hello, world!"
+
+    class Subscription(ObjectType):
+        time_of_day = String()
+
+        async def subscribe_time_of_day(root, info):
+            while True:
+                yield datetime.now().isoformat()
+                await asyncio.sleep(1)
+
+    schema = Schema(query=Query, subscription=Subscription)
+
+    async def main(schema):
+        subscription = 'subscription { timeOfDay }'
+        result = await schema.subscribe(subscription)
+        async for item in result:
+            print(item.data['timeOfDay'])
+
+    asyncio.run(main(schema))
+
+The ``result`` is an async iterator which yields items in the same manner as a query.


### PR DESCRIPTION
There was a bug in the example code for subscriptions. This PR fixes it as well as moving the documentation into a seperate file.