### PR TITLE
Fix Typo in Docs

### DIFF
--- a/docs/execution/execute.rst
+++ b/docs/execution/execute.rst
@@ -85,7 +85,7 @@ Value used for :ref:`ResolverParamParent` in root queries and mutations can be o
             return {'id': root.id, 'firstName': root.name}
 
     schema = Schema(Query)
-    user_root = User(id=12, name='bob'}
+    user_root = User(id=12, name='bob')
     result = schema.execute(
         '''
         query getUser {


### PR DESCRIPTION
The example of executing a query by passing a root value had a typo for
the trailing parenthesis, namely it was '}' instead of ')'.