### PR TITLE
add BigInt type

### DIFF
--- a/graphene/types/scalars.py
+++ b/graphene/types/scalars.py
@@ -82,6 +82,33 @@ class Int(Scalar):
                 return num
 
 
+class BigInt(Scalar):
+    """
+    The `BigInt` scalar type represents non-fractional whole numeric values.
+    `BigInt` is not constrained to 32-bit like the `Int` type and thus is a less
+    compatible type.
+    """
+
+    @staticmethod
+    def coerce_int(value):
+        try:
+            num = int(value)
+        except ValueError:
+            try:
+                num = int(float(value))
+            except ValueError:
+                return None
+        return num
+
+    serialize = coerce_int
+    parse_value = coerce_int
+
+    @staticmethod
+    def parse_literal(ast):
+        if isinstance(ast, IntValueNode):
+            return int(ast.value)
+
+
 class Float(Scalar):
     """
     The `Float` scalar type represents signed double-precision fractional

--- a/graphene/types/tests/test_scalar.py
+++ b/graphene/types/tests/test_scalar.py
@@ -1,4 +1,5 @@
 from ..scalars import Scalar, Int, BigInt
+from graphql.language.ast import IntValueNode
 
 
 def test_scalar():
@@ -11,10 +12,18 @@ def test_scalar():
 
 def test_ints():
     assert Int.parse_value(2 ** 31 - 1) is not None
+    assert Int.parse_value("2.0") is not None
     assert Int.parse_value(2 ** 31) is None
+
+    assert Int.parse_literal(IntValueNode(value=str(2 ** 31 - 1))) == 2 ** 31 - 1
+    assert Int.parse_literal(IntValueNode(value=str(2 ** 31))) is None
 
     assert Int.parse_value(-(2 ** 31)) is not None
     assert Int.parse_value(-(2 ** 31) - 1) is None
 
     assert BigInt.parse_value(2 ** 31) is not None
+    assert BigInt.parse_value("2.0") is not None
     assert BigInt.parse_value(-(2 ** 31) - 1) is not None
+
+    assert BigInt.parse_literal(IntValueNode(value=str(2 ** 31 - 1))) == 2 ** 31 - 1
+    assert BigInt.parse_literal(IntValueNode(value=str(2 ** 31))) == 2 ** 31

--- a/graphene/types/tests/test_scalar.py
+++ b/graphene/types/tests/test_scalar.py
@@ -13,8 +13,8 @@ def test_ints():
     assert Int.parse_value(2 ** 31 - 1) is not None
     assert Int.parse_value(2 ** 31) is None
 
-    assert Int.parse_value(-2 ** 31) is not None
-    assert Int.parse_value(-2 ** 31 - 1) is None
+    assert Int.parse_value(-(2 ** 31)) is not None
+    assert Int.parse_value(-(2 ** 31) - 1) is None
 
     assert BigInt.parse_value(2 ** 31) is not None
-    assert BigInt.parse_value(-2 ** 31 - 1) is not None
+    assert BigInt.parse_value(-(2 ** 31) - 1) is not None

--- a/graphene/types/tests/test_scalar.py
+++ b/graphene/types/tests/test_scalar.py
@@ -1,4 +1,4 @@
-from ..scalars import Scalar
+from ..scalars import Scalar, Int, BigInt
 
 
 def test_scalar():
@@ -7,3 +7,14 @@ def test_scalar():
 
     assert JSONScalar._meta.name == "JSONScalar"
     assert JSONScalar._meta.description == "Documentation"
+
+
+def test_ints():
+    assert Int.parse_value(2 ** 31 - 1) is not None
+    assert Int.parse_value(2 ** 31) is None
+
+    assert Int.parse_value(-2 ** 31) is not None
+    assert Int.parse_value(-2 ** 31 - 1) is None
+
+    assert BigInt.parse_value(2 ** 31) is not None
+    assert BigInt.parse_value(-2 ** 31 - 1) is not None


### PR DESCRIPTION
Custom type for bigger integers.

While less compatible (according to the GraphQL spec) it works for most major JS implementations.