### PR TITLE
Remove Object Mutation dead link from Relay docs

### DIFF
--- a/docs/relay/index.rst
+++ b/docs/relay/index.rst
@@ -26,4 +26,3 @@ Useful links
 .. _Getting started with Relay: https://facebook.github.io/relay/docs/en/quick-start-guide.html
 .. _Relay Global Identification Specification: https://facebook.github.io/relay/graphql/objectidentification.htm
 .. _Relay Cursor Connection Specification: https://facebook.github.io/relay/graphql/connections.htm
-.. _Relay input Object Mutation: https://facebook.github.io/relay/graphql/mutations.htm


### PR DESCRIPTION
The official Relay project has removed 'Relay input Object Mutation' in favour of general mutation spec from their docs in [this PR](https://github.com/facebook/relay/pull/2401/files#diff-98bee0595817d7a46cd52d86e6c3db70) and is unavailable on their [official website](https://relay.dev/docs/en/graphql-server-specification#further-reading) as well