### PR TITLE
Argument default value should be undefined

### DIFF
--- a/examples/starwars_relay/tests/snapshots/snap_test_objectidentification.py
+++ b/examples/starwars_relay/tests/snapshots/snap_test_objectidentification.py
@@ -8,9 +8,7 @@ from snapshottest import Snapshot
 snapshots = Snapshot()
 
 snapshots["test_correctly_fetches_id_name_rebels 1"] = {
-    "data": {
-        "rebels": {"id": "RmFjdGlvbjox", "name": "Alliance to Restore the Republic"}
-    }
+    "data": {"rebels": {"id": "RmFjdGlvbjox", "name": "Alliance to Restore the Republic"}}
 }
 
 snapshots["test_correctly_refetches_rebels 1"] = {
@@ -21,13 +19,9 @@ snapshots["test_correctly_fetches_id_name_empire 1"] = {
     "data": {"empire": {"id": "RmFjdGlvbjoy", "name": "Galactic Empire"}}
 }
 
-snapshots["test_correctly_refetches_empire 1"] = {
-    "data": {"node": {"id": "RmFjdGlvbjoy", "name": "Galactic Empire"}}
-}
+snapshots["test_correctly_refetches_empire 1"] = {"data": {"node": {"id": "RmFjdGlvbjoy", "name": "Galactic Empire"}}}
 
-snapshots["test_correctly_refetches_xwing 1"] = {
-    "data": {"node": {"id": "U2hpcDox", "name": "X-Wing"}}
-}
+snapshots["test_correctly_refetches_xwing 1"] = {"data": {"node": {"id": "U2hpcDox", "name": "X-Wing"}}}
 
 snapshots[
     "test_str_schema 1"
@@ -49,7 +43,7 @@ type Faction implements Node {
   name: String
 
   """The ships used by the faction."""
-  ships(before: String = null, after: String = null, first: Int = null, last: Int = null): ShipConnection
+  ships(before: String, after: String, first: Int, last: Int): ShipConnection
 }
 
 """An object with an ID"""

--- a/examples/starwars_relay/tests/snapshots/snap_test_objectidentification.py
+++ b/examples/starwars_relay/tests/snapshots/snap_test_objectidentification.py
@@ -8,7 +8,9 @@ from snapshottest import Snapshot
 snapshots = Snapshot()
 
 snapshots["test_correctly_fetches_id_name_rebels 1"] = {
-    "data": {"rebels": {"id": "RmFjdGlvbjox", "name": "Alliance to Restore the Republic"}}
+    "data": {
+        "rebels": {"id": "RmFjdGlvbjox", "name": "Alliance to Restore the Republic"}
+    }
 }
 
 snapshots["test_correctly_refetches_rebels 1"] = {
@@ -19,9 +21,13 @@ snapshots["test_correctly_fetches_id_name_empire 1"] = {
     "data": {"empire": {"id": "RmFjdGlvbjoy", "name": "Galactic Empire"}}
 }
 
-snapshots["test_correctly_refetches_empire 1"] = {"data": {"node": {"id": "RmFjdGlvbjoy", "name": "Galactic Empire"}}}
+snapshots["test_correctly_refetches_empire 1"] = {
+    "data": {"node": {"id": "RmFjdGlvbjoy", "name": "Galactic Empire"}}
+}
 
-snapshots["test_correctly_refetches_xwing 1"] = {"data": {"node": {"id": "U2hpcDox", "name": "X-Wing"}}}
+snapshots["test_correctly_refetches_xwing 1"] = {
+    "data": {"node": {"id": "U2hpcDox", "name": "X-Wing"}}
+}
 
 snapshots[
     "test_str_schema 1"

--- a/graphene/types/argument.py
+++ b/graphene/types/argument.py
@@ -1,5 +1,7 @@
 from itertools import chain
 
+from graphql import Undefined
+
 from .dynamic import Dynamic
 from .mountedtype import MountedType
 from .structures import NonNull
@@ -41,7 +43,7 @@ class Argument(MountedType):
     def __init__(
         self,
         type_,
-        default_value=None,
+        default_value=Undefined,
         description=None,
         name=None,
         required=False,
@@ -102,9 +104,7 @@ def to_arguments(args, extra_args=None):
             raise ValueError(f'Unknown argument "{default_name}".')
 
         arg_name = default_name or arg.name
-        assert (
-            arg_name not in arguments
-        ), f'More than one Argument have same name "{arg_name}".'
+        assert arg_name not in arguments, f'More than one Argument have same name "{arg_name}".'
         arguments[arg_name] = arg
 
     return arguments

--- a/graphene/types/argument.py
+++ b/graphene/types/argument.py
@@ -104,7 +104,9 @@ def to_arguments(args, extra_args=None):
             raise ValueError(f'Unknown argument "{default_name}".')
 
         arg_name = default_name or arg.name
-        assert arg_name not in arguments, f'More than one Argument have same name "{arg_name}".'
+        assert (
+            arg_name not in arguments
+        ), f'More than one Argument have same name "{arg_name}".'
         arguments[arg_name] = arg
 
     return arguments

--- a/graphene/types/tests/test_query.py
+++ b/graphene/types/tests/test_query.py
@@ -128,7 +128,9 @@ def test_query_interface():
 
     executed = hello_schema.execute("{ interfaces { __typename } }")
     assert not executed.errors
-    assert executed.data == {"interfaces": [{"__typename": "One"}, {"__typename": "Two"}]}
+    assert executed.data == {
+        "interfaces": [{"__typename": "One"}, {"__typename": "Two"}]
+    }
 
 
 def test_query_dynamic():
@@ -177,7 +179,10 @@ def test_query_wrong_default_value():
 
     executed = hello_schema.execute("{ hello { field } }")
     assert len(executed.errors) == 1
-    assert executed.errors[0].message == GraphQLError("Expected value of type 'MyType' but got: 'hello'.").message
+    assert (
+        executed.errors[0].message
+        == GraphQLError("Expected value of type 'MyType' but got: 'hello'.").message
+    )
     assert executed.data == {"hello": None}
 
 
@@ -259,9 +264,13 @@ def test_query_input_field():
     assert not result.errors
     assert result.data == {"test": '["Source!",{"a_input":{"a_field":"String!"}}]'}
 
-    result = test_schema.execute('{ test(aInput: {recursiveField: {aField: "String!"}}) }', "Source!")
+    result = test_schema.execute(
+        '{ test(aInput: {recursiveField: {aField: "String!"}}) }', "Source!"
+    )
     assert not result.errors
-    assert result.data == {"test": '["Source!",{"a_input":{"recursive_field":{"a_field":"String!"}}}]'}
+    assert result.data == {
+        "test": '["Source!",{"a_input":{"recursive_field":{"a_field":"String!"}}}]'
+    }
 
 
 def test_query_middlewares():
@@ -280,7 +289,9 @@ def test_query_middlewares():
 
     hello_schema = Schema(Query)
 
-    executed = hello_schema.execute("{ hello, other }", middleware=[reversed_middleware])
+    executed = hello_schema.execute(
+        "{ hello, other }", middleware=[reversed_middleware]
+    )
     assert not executed.errors
     assert executed.data == {"hello": "dlroW", "other": "rehto"}
 
@@ -386,7 +397,11 @@ def test_big_list_of_containers_multiple_fields_query_benchmark(benchmark):
     big_list_query = partial(hello_schema.execute, "{ allContainers { x, y, z, o } }")
     result = benchmark(big_list_query)
     assert not result.errors
-    assert result.data == {"allContainers": [{"x": c.x, "y": c.y, "z": c.z, "o": c.o} for c in big_container_list]}
+    assert result.data == {
+        "allContainers": [
+            {"x": c.x, "y": c.y, "z": c.z, "o": c.o} for c in big_container_list
+        ]
+    }
 
 
 def test_big_list_of_containers_multiple_fields_custom_resolvers_query_benchmark(
@@ -423,7 +438,11 @@ def test_big_list_of_containers_multiple_fields_custom_resolvers_query_benchmark
     big_list_query = partial(hello_schema.execute, "{ allContainers { x, y, z, o } }")
     result = benchmark(big_list_query)
     assert not result.errors
-    assert result.data == {"allContainers": [{"x": c.x, "y": c.y, "z": c.z, "o": c.o} for c in big_container_list]}
+    assert result.data == {
+        "allContainers": [
+            {"x": c.x, "y": c.y, "z": c.z, "o": c.o} for c in big_container_list
+        ]
+    }
 
 
 def test_query_annotated_resolvers():

--- a/graphene/types/tests/test_query.py
+++ b/graphene/types/tests/test_query.py
@@ -128,9 +128,7 @@ def test_query_interface():
 
     executed = hello_schema.execute("{ interfaces { __typename } }")
     assert not executed.errors
-    assert executed.data == {
-        "interfaces": [{"__typename": "One"}, {"__typename": "Two"}]
-    }
+    assert executed.data == {"interfaces": [{"__typename": "One"}, {"__typename": "Two"}]}
 
 
 def test_query_dynamic():
@@ -179,10 +177,7 @@ def test_query_wrong_default_value():
 
     executed = hello_schema.execute("{ hello { field } }")
     assert len(executed.errors) == 1
-    assert (
-        executed.errors[0].message
-        == GraphQLError("Expected value of type 'MyType' but got: 'hello'.").message
-    )
+    assert executed.errors[0].message == GraphQLError("Expected value of type 'MyType' but got: 'hello'.").message
     assert executed.data == {"hello": None}
 
 
@@ -229,11 +224,11 @@ def test_query_arguments():
 
     result = test_schema.execute("{ test }", None)
     assert not result.errors
-    assert result.data == {"test": '[null,{"a_str":null,"a_int":null}]'}
+    assert result.data == {"test": "[null,{}]"}
 
     result = test_schema.execute('{ test(aStr: "String!") }', "Source!")
     assert not result.errors
-    assert result.data == {"test": '["Source!",{"a_str":"String!","a_int":null}]'}
+    assert result.data == {"test": '["Source!",{"a_str":"String!"}]'}
 
     result = test_schema.execute('{ test(aInt: -123, aStr: "String!") }', "Source!")
     assert not result.errors
@@ -258,19 +253,15 @@ def test_query_input_field():
 
     result = test_schema.execute("{ test }", None)
     assert not result.errors
-    assert result.data == {"test": '[null,{"a_input":null}]'}
+    assert result.data == {"test": "[null,{}]"}
 
     result = test_schema.execute('{ test(aInput: {aField: "String!"} ) }', "Source!")
     assert not result.errors
     assert result.data == {"test": '["Source!",{"a_input":{"a_field":"String!"}}]'}
 
-    result = test_schema.execute(
-        '{ test(aInput: {recursiveField: {aField: "String!"}}) }', "Source!"
-    )
+    result = test_schema.execute('{ test(aInput: {recursiveField: {aField: "String!"}}) }', "Source!")
     assert not result.errors
-    assert result.data == {
-        "test": '["Source!",{"a_input":{"recursive_field":{"a_field":"String!"}}}]'
-    }
+    assert result.data == {"test": '["Source!",{"a_input":{"recursive_field":{"a_field":"String!"}}}]'}
 
 
 def test_query_middlewares():
@@ -289,9 +280,7 @@ def test_query_middlewares():
 
     hello_schema = Schema(Query)
 
-    executed = hello_schema.execute(
-        "{ hello, other }", middleware=[reversed_middleware]
-    )
+    executed = hello_schema.execute("{ hello, other }", middleware=[reversed_middleware])
     assert not executed.errors
     assert executed.data == {"hello": "dlroW", "other": "rehto"}
 
@@ -397,11 +386,7 @@ def test_big_list_of_containers_multiple_fields_query_benchmark(benchmark):
     big_list_query = partial(hello_schema.execute, "{ allContainers { x, y, z, o } }")
     result = benchmark(big_list_query)
     assert not result.errors
-    assert result.data == {
-        "allContainers": [
-            {"x": c.x, "y": c.y, "z": c.z, "o": c.o} for c in big_container_list
-        ]
-    }
+    assert result.data == {"allContainers": [{"x": c.x, "y": c.y, "z": c.z, "o": c.o} for c in big_container_list]}
 
 
 def test_big_list_of_containers_multiple_fields_custom_resolvers_query_benchmark(
@@ -438,11 +423,7 @@ def test_big_list_of_containers_multiple_fields_custom_resolvers_query_benchmark
     big_list_query = partial(hello_schema.execute, "{ allContainers { x, y, z, o } }")
     result = benchmark(big_list_query)
     assert not result.errors
-    assert result.data == {
-        "allContainers": [
-            {"x": c.x, "y": c.y, "z": c.z, "o": c.o} for c in big_container_list
-        ]
-    }
+    assert result.data == {"allContainers": [{"x": c.x, "y": c.y, "z": c.z, "o": c.o} for c in big_container_list]}
 
 
 def test_query_annotated_resolvers():

--- a/graphene/types/tests/test_type_map.py
+++ b/graphene/types/tests/test_type_map.py
@@ -1,3 +1,4 @@
+from graphql import Undefined
 from graphql.type import (
     GraphQLArgument,
     GraphQLEnumType,
@@ -51,9 +52,7 @@ def test_enum():
     assert graphql_enum.name == "MyEnum"
     assert graphql_enum.description == "Description"
     assert graphql_enum.values == {
-        "foo": GraphQLEnumValue(
-            value=1, description="Description foo=1", deprecation_reason="Is deprecated"
-        ),
+        "foo": GraphQLEnumValue(value=1, description="Description foo=1", deprecation_reason="Is deprecated"),
         "bar": GraphQLEnumValue(value=2, description="Description bar=2"),
     }
 
@@ -227,9 +226,7 @@ def test_objecttype_camelcase():
     assert list(fields) == ["fooBar"]
     foo_field = fields["fooBar"]
     assert isinstance(foo_field, GraphQLField)
-    assert foo_field.args == {
-        "barFoo": GraphQLArgument(GraphQLString, default_value=None, out_name="bar_foo")
-    }
+    assert foo_field.args == {"barFoo": GraphQLArgument(GraphQLString, default_value=Undefined, out_name="bar_foo")}
 
 
 def test_objecttype_camelcase_disabled():
@@ -249,11 +246,7 @@ def test_objecttype_camelcase_disabled():
     assert list(fields) == ["foo_bar"]
     foo_field = fields["foo_bar"]
     assert isinstance(foo_field, GraphQLField)
-    assert foo_field.args == {
-        "bar_foo": GraphQLArgument(
-            GraphQLString, default_value=None, out_name="bar_foo"
-        )
-    }
+    assert foo_field.args == {"bar_foo": GraphQLArgument(GraphQLString, default_value=Undefined, out_name="bar_foo")}
 
 
 def test_objecttype_with_possible_types():

--- a/graphene/types/tests/test_type_map.py
+++ b/graphene/types/tests/test_type_map.py
@@ -52,7 +52,9 @@ def test_enum():
     assert graphql_enum.name == "MyEnum"
     assert graphql_enum.description == "Description"
     assert graphql_enum.values == {
-        "foo": GraphQLEnumValue(value=1, description="Description foo=1", deprecation_reason="Is deprecated"),
+        "foo": GraphQLEnumValue(
+            value=1, description="Description foo=1", deprecation_reason="Is deprecated"
+        ),
         "bar": GraphQLEnumValue(value=2, description="Description bar=2"),
     }
 
@@ -226,7 +228,11 @@ def test_objecttype_camelcase():
     assert list(fields) == ["fooBar"]
     foo_field = fields["fooBar"]
     assert isinstance(foo_field, GraphQLField)
-    assert foo_field.args == {"barFoo": GraphQLArgument(GraphQLString, default_value=Undefined, out_name="bar_foo")}
+    assert foo_field.args == {
+        "barFoo": GraphQLArgument(
+            GraphQLString, default_value=Undefined, out_name="bar_foo"
+        )
+    }
 
 
 def test_objecttype_camelcase_disabled():
@@ -246,7 +252,11 @@ def test_objecttype_camelcase_disabled():
     assert list(fields) == ["foo_bar"]
     foo_field = fields["foo_bar"]
     assert isinstance(foo_field, GraphQLField)
-    assert foo_field.args == {"bar_foo": GraphQLArgument(GraphQLString, default_value=Undefined, out_name="bar_foo")}
+    assert foo_field.args == {
+        "bar_foo": GraphQLArgument(
+            GraphQLString, default_value=Undefined, out_name="bar_foo"
+        )
+    }
 
 
 def test_objecttype_with_possible_types():


### PR DESCRIPTION
resolves #1195

This stops `null` from being populated in the introspection query as mentioned in #1195. This also solves the problem of `None` being passed into the kwargs of a `mutate` call if no value was passed in by the end user.