### PR TITLE
Propagate arguments of relay.NodeField to Field (#1036)

### DIFF
--- a/graphene/relay/node.py
+++ b/graphene/relay/node.py
@@ -48,7 +48,7 @@ class GlobalID(Field):
 
 
 class NodeField(Field):
-    def __init__(self, node, type=False, deprecation_reason=None, name=None, **kwargs):
+    def __init__(self, node, type=False, **kwargs):
         assert issubclass(node, Node), "NodeField can only operate in Nodes"
         self.node_type = node
         self.field_type = type
@@ -57,8 +57,8 @@ class NodeField(Field):
             # If we don's specify a type, the field type will be the node
             # interface
             type or node,
-            description="The ID of the object",
-            id=ID(required=True),
+            id=ID(required=True, description="The ID of the object"),
+            **kwargs
         )
 
     def get_resolver(self, parent_resolver):

--- a/graphene/relay/tests/test_node.py
+++ b/graphene/relay/tests/test_node.py
@@ -110,6 +110,17 @@ def test_node_field_custom():
     assert node_field.node_type == Node
 
 
+def test_node_field_args():
+    field_args = {
+        "name": "my_custom_name",
+        "description": "my_custom_description",
+        "deprecation_reason": "my_custom_deprecation_reason",
+    }
+    node_field = Node.Field(**field_args)
+    for field_arg, value in field_args.items():
+        assert getattr(node_field, field_arg) == value
+
+
 def test_node_field_only_type():
     executed = schema.execute(
         '{ onlyNode(id:"%s") { __typename, name } } ' % Node.to_global_id("MyNode", 1)


### PR DESCRIPTION
* Propagate name, deprecation_reason arguments of relay.NodeField to Field

* Allow custom description in Node.Field and move ID description to ID argument

* Add test for Node.Field with custom name

* Add tests for description, deprecation_reason arguments of NodeField

* Pass all kwargs from NodeField to Field