### PR TITLE
Raise error when arguments conains only type annotations

### DIFF
--- a/graphene/types/argument.py
+++ b/graphene/types/argument.py
@@ -75,6 +75,10 @@ def to_arguments(args, extra_args=None):
     from .field import Field
     from .inputfield import InputField
 
+    if type(args) == dict and len(args) == 1 and '__annotations__' in args:
+        raise ValueError(f"Arguments class doesn't have any field but has type annotations. "
+                         f"You probably used ':' instead of '=' in class definition")
+
     if extra_args:
         extra_args = sorted(extra_args.items(), key=lambda f: f[1])
     else:

--- a/graphene/types/tests/test_argument.py
+++ b/graphene/types/tests/test_argument.py
@@ -7,6 +7,8 @@ from ..field import Field
 from ..inputfield import InputField
 from ..scalars import String
 from ..structures import NonNull
+from ..mutation import Mutation
+from graphene.utils.props import props
 
 
 def test_argument():
@@ -74,3 +76,16 @@ def test_argument_with_lazy_partial_type():
     MyType = object()
     arg = Argument(partial(lambda: MyType))
     assert arg.type == MyType
+
+
+def test_arguments_raise_if_type_annotations():
+    class Arguments:
+        id: String()
+
+    with raises(ValueError) as exec_info:
+        to_arguments(props(Arguments))
+
+    assert str(exec_info.value) == (
+        f"Arguments class doesn't have any field but has type annotations. "
+        f"You probably used ':' instead of '=' in class definition"
+    )


### PR DESCRIPTION
Hello,

I'm a new user of graphene and I found it pretty cool for now !

But I came across a little annoying problem: I keep using `:` instead of `=` when defining types...

I suggest to add an error to detect this and give an error explicitly saying to the developer what is wrong with his use of the library.

This is a first approach, but we should probably make this a more general check, since it can occur in any graphql type definition, not only Arguments.

If you have suggestion about how to apply this more generaly, or if you think it's ok to make ad-hok checks, please comment :-)  