### PR TITLE
Use argument's `default_value` regardless if the input field is required

### DIFF
--- a/graphene/types/schema.py
+++ b/graphene/types/schema.py
@@ -26,7 +26,6 @@ from graphql import (
     GraphQLObjectType,
     GraphQLSchema,
     GraphQLString,
-    Undefined,
 )
 from graphql.execution import ExecutionContext
 from graphql.execution.values import get_argument_values

--- a/graphene/types/schema.py
+++ b/graphene/types/schema.py
@@ -313,9 +313,7 @@ class TypeMap(dict):
                         arg_type,
                         out_name=arg_name,
                         description=arg.description,
-                        default_value=Undefined
-                        if isinstance(arg.type, NonNull)
-                        else arg.default_value,
+                        default_value=arg.default_value,
                     )
                 subscribe = field.wrap_subscribe(
                     self.get_function_for_type(

--- a/graphene/types/tests/test_type_map.py
+++ b/graphene/types/tests/test_type_map.py
@@ -97,9 +97,7 @@ def test_objecttype():
 
 def test_required_argument_with_default_value():
     class MyObjectType(ObjectType):
-        foo = String(
-            bar=String(required=True, default_value="x")
-        )
+        foo = String(bar=String(required=True, default_value="x"))
 
     type_map = create_type_map([MyObjectType])
 

--- a/graphene/types/tests/test_type_map.py
+++ b/graphene/types/tests/test_type_map.py
@@ -6,6 +6,7 @@ from graphql.type import (
     GraphQLInputField,
     GraphQLInputObjectType,
     GraphQLInterfaceType,
+    GraphQLNonNull,
     GraphQLObjectType,
     GraphQLString,
 )
@@ -92,6 +93,23 @@ def test_objecttype():
             out_name="bar",
         )
     }
+
+
+def test_required_argument_with_default_value():
+    class MyObjectType(ObjectType):
+        foo = String(
+            bar=String(required=True, default_value="x")
+        )
+
+    type_map = create_type_map([MyObjectType])
+
+    graphql_type = type_map["MyObjectType"]
+    foo_field = graphql_type.fields["foo"]
+
+    bar_argument = foo_field.args["bar"]
+    assert bar_argument.default_value == "x"
+    assert isinstance(bar_argument.type, GraphQLNonNull)
+    assert bar_argument.type.of_type == GraphQLString
 
 
 def test_dynamic_objecttype():


### PR DESCRIPTION
The [GraphQL spec](https://github.com/graphql/graphql-spec/pull/418) allows a required argument to have a default value. In fact, [Graphene v2 supports this behavior](https://github.com/graphql-python/graphene/blob/v2/graphene/types/typemap.py#L294). However, for some reason, this is not allows in [Graphene v3](https://github.com/graphql-python/graphene/pull/1048/files#diff-f066ce1b84329fbfb7cd0e5d5027a51f68e14677754aab172fbc91dea42c519dR360-R362).