### PR TITLE
Include extra data in Meta in _meta

### DIFF
--- a/graphene/types/base.py
+++ b/graphene/types/base.py
@@ -43,6 +43,7 @@ class BaseType(SubclassWithMeta):
             return
         _meta.name = name or cls.__name__
         _meta.description = description or trim_docstring(cls.__doc__)
+        _meta.extra = _kwargs
         _meta.freeze()
         cls._meta = _meta
         super(BaseType, cls).__init_subclass_with_meta__()


### PR DESCRIPTION
I'm building an authorization middleware and I want to include functions/data in the Meta class to store the relevant information in the class itself.
However, all custom args in Meta are dropped at the moment.
I think there shouldn't be an issue to include other args in an extra attribute of _meta.