### PR TITLE
Allow later aniso8601 releases

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,7 @@ setup(
     install_requires=[
         "graphql-core>=3.1.2,<4",
         "graphql-relay>=3.0,<4",
-        "aniso8601>=8,<9",
+        "aniso8601>=8,<10",
     ],
     tests_require=tests_require,
     extras_require={"test": tests_require, "dev": dev_requires},


### PR DESCRIPTION
The latest `aniso8601` release 9.0.1. With 9.x.x was the support for Python 2 [removed](https://bitbucket.org/nielsenb/aniso8601/src/master/CHANGELOG.rst).

Distributions are starting to ship `aniso8601-9.0.1` which is not covered by the current version constraint.