### PR TITLE
Create Either Argument decorator

### DIFF
--- a/graphene/utils/decorators.py
+++ b/graphene/utils/decorators.py
@@ -15,7 +15,7 @@ def either(expected):
             if not any(arg_list):
                 raise TooFewArgs("Too few arguments, must be either of: " + ",".join(expected))
 
-            if all(arg_list) or arg_list.count(True) > 1:
+            if arg_list.count(True) > 1:
                 raise TooManyArgs("Too many arguments, must be either of: " + ",".join(expected))
 
             return func(*args, **kwargs)

--- a/graphene/utils/decorators.py
+++ b/graphene/utils/decorators.py
@@ -15,7 +15,7 @@ def either(expected):
             if not any(arg_list):
                 raise TooFewArgs("Too few arguments, must be either of: " + ",".join(expected))
 
-            if all(arg_list):
+            if all(arg_list) or arg_list.count(True) > 1:
                 raise TooManyArgs("Too many arguments, must be either of: " + ",".join(expected))
 
             return func(*args, **kwargs)

--- a/graphene/utils/decorators.py
+++ b/graphene/utils/decorators.py
@@ -1,0 +1,23 @@
+class TooManyArgs(Exception):
+    pass
+
+
+class TooFewArgs(Exception):
+    pass
+
+
+def either(expected):
+    def inner(func):
+        def wrapper(*args, **kwargs):
+
+            arg_list = [kwargs.get(arg, None) is not None for arg in expected]
+
+            if not any(arg_list):
+                raise TooFewArgs("Too few arguments, must be either of: " + ",".join(expected))
+
+            if all(arg_list):
+                raise TooManyArgs("Too many arguments, must be either of: " + ",".join(expected))
+
+            return func(*args, **kwargs)
+        return wrapper
+    return inner


### PR DESCRIPTION
Adds a decorator for handling situations when a query expects different arguments, but can only work with one. For instance:

A query named `userByAttr` can retrieve a user by their email or username, but not both. In this case, we define the query as follows:

```
from graphene.utils.decorators import either

@either(["username", "email"])
def resolve_user_by_attr(root, info, username=None, email=None):
        ...
```

If both arguments were passed, the query will raise `TooManyArgs`.
If no expected argument was passed, the query will raise `TooFewArgs`