### PR TITLE
Make Decimal type return None if parsing an empty string

### DIFF
--- a/graphene/types/decimal.py
+++ b/graphene/types/decimal.py
@@ -28,6 +28,8 @@ class Decimal(Scalar):
 
     @staticmethod
     def parse_value(value):
+        if value == "":
+            return None
         try:
             return _Decimal(value)
         except ValueError:

--- a/graphene/types/tests/test_decimal.py
+++ b/graphene/types/tests/test_decimal.py
@@ -6,7 +6,7 @@ from ..schema import Schema
 
 
 class Query(ObjectType):
-    decimal = Decimal(input=Decimal())
+    decimal = Decimal(input=Decimal(required=False))
 
     def resolve_decimal(self, info, input):
         return input
@@ -49,3 +49,10 @@ def test_decimal_string_query_integer():
     assert not result.errors
     assert result.data == {"decimal": str(decimal_value)}
     assert decimal.Decimal(result.data["decimal"]) == decimal_value
+
+def test_parse_decimal_empty_string():
+    """Parsing an empty string should return None"""
+    result = schema.execute("""{ decimal(input: \"\") }""")
+    assert not result.errors
+    assert result.data == {"decimal": None}
+

--- a/graphene/types/tests/test_decimal.py
+++ b/graphene/types/tests/test_decimal.py
@@ -6,7 +6,7 @@ from ..schema import Schema
 
 
 class Query(ObjectType):
-    decimal = Decimal(input=Decimal(required=False))
+    decimal = Decimal(input=Decimal())
 
     def resolve_decimal(self, info, input):
         return input


### PR DESCRIPTION
Would fix #927.

When using forms in the frontend, it's often useful for the "null" value of the form field to be an empty string, as HTML Input elements don't take null for a value. When converting that form value into a Graphene Decimal type, an empty string will currently cause a ConversionError. This PR makes empty strings a valid "null" value for Decimal.