### PR TITLE
Add support for Enum inheritance

### DIFF
--- a/graphene/types/enum.py
+++ b/graphene/types/enum.py
@@ -1,4 +1,5 @@
 from enum import Enum as PyEnum
+from typing import Iterable, Type, Optional
 
 from graphene.utils.subclass_with_meta import SubclassWithMeta_Meta
 
@@ -18,11 +19,18 @@ EnumType = type(PyEnum)
 class EnumOptions(BaseOptions):
     enum = None  # type: Enum
     deprecation_reason = None
+    enums = ()  # type: Iterable[Type[Enum]]
 
 
 class EnumMeta(SubclassWithMeta_Meta):
     def __new__(cls, name_, bases, classdict, **options):
-        enum_members = dict(classdict, __eq__=eq_enum)
+        enum_members = dict(__eq__=eq_enum)
+        meta = classdict.get("Meta", None)  # type: Optional[EnumOptions]
+        if meta and hasattr(meta, 'enums'):
+            for enum in meta.enums:
+                enum_members.update(enum.as_dict())
+        enum_members.update(classdict)
+
         # We remove the Meta attribute from the class to not collide
         # with the enum values.
         enum_members.pop("Meta", None)
@@ -106,3 +114,10 @@ class Enum(UnmountedType, BaseType, metaclass=EnumMeta):
         is mounted (as a Field, InputField or Argument)
         """
         return cls
+
+    @classmethod
+    def as_dict(cls):
+        return {
+            enum_meta.name: enum_meta.value
+            for _, enum_meta in cls._meta.enum.__members__.items()
+        }

--- a/graphene/types/tests/test_enum.py
+++ b/graphene/types/tests/test_enum.py
@@ -477,8 +477,11 @@ def test_enum_inheritance():
     class ParentRGB(Enum):
         RED = 1
 
-    class ChildRGB(ParentRGB, Enum):
+    class ChildRGB(Enum):
         BLUE = 2
+
+        class Meta:
+            enums = (ParentRGB,)
 
     class Query(ObjectType):
         color = ChildRGB(required=True)

--- a/graphene/types/tests/test_enum.py
+++ b/graphene/types/tests/test_enum.py
@@ -486,9 +486,6 @@ def test_enum_inheritance():
     class Query(ObjectType):
         color = ChildRGB(required=True)
 
-        def resolve_color(_, info):
-            return ChildRGB.RED
-
     schema = Schema(query=Query)
     assert str(schema) == dedent(
         '''\
@@ -502,3 +499,49 @@ def test_enum_inheritance():
         }
     '''
     )
+
+
+def test_multiple_enum_inheritance():
+    class Parent1RGB(Enum):
+        RED = 1
+
+    class Parent2RGB(Enum):
+        BLUE = 2
+
+    class ChildRGB(Enum):
+        GREEN = 3
+
+        class Meta:
+            enums = (Parent1RGB, Parent2RGB,)
+
+    class Query(ObjectType):
+        color = ChildRGB(required=True)
+
+    schema = Schema(query=Query)
+    assert str(schema) == dedent(
+        '''\
+        type Query {
+          color: ChildRGB!
+        }
+
+        enum ChildRGB {
+          RED
+          BLUE
+          GREEN
+        }
+    '''
+    )
+
+
+def test_override_enum_inheritance():
+    class ParentRGB(Enum):
+        RED = 1
+        BLUE = 2
+
+    class ChildRGB(Enum):
+        BLUE = 3
+
+        class Meta:
+            enums = (ParentRGB,)
+
+    assert ChildRGB.get(3) != ParentRGB.BLUE

--- a/graphene/types/tests/test_enum.py
+++ b/graphene/types/tests/test_enum.py
@@ -471,3 +471,31 @@ def test_mutation_enum_input_type():
     assert result.data == {"createPaint": {"color": "RED"}}
 
     assert color_input_value == RGB.RED
+
+
+def test_enum_inheritance():
+    class ParentRGB(Enum):
+        RED = 1
+
+    class ChildRGB(ParentRGB, Enum):
+        BLUE = 2
+
+    class Query(ObjectType):
+        color = ChildRGB(required=True)
+
+        def resolve_color(_, info):
+            return ChildRGB.RED
+
+    schema = Schema(query=Query)
+    assert str(schema) == dedent(
+        '''\
+        type Query {
+          color: ChildRGB!
+        }
+
+        enum ChildRGB {
+          RED
+          BLUE
+        }
+    '''
+    )


### PR DESCRIPTION
Due to fact that python's Enum [doesn't support inheritance](https://docs.python.org/3/library/enum.html#restricted-enum-subclassing), and in some cases it might be useful, so I added this functionality to graphene's Enum.