### PR TITLE
Increased MAX_INT and MIN_INT to +(2^53 - 1) and -(2^53 - 1)

### DIFF
--- a/graphene/types/scalars.py
+++ b/graphene/types/scalars.py
@@ -47,8 +47,8 @@ class Scalar(UnmountedType, BaseType):
 #
 # n.b. JavaScript's integers are safe between -(2^53 - 1) and 2^53 - 1 because
 # they are internally represented as IEEE 754 doubles.
-MAX_INT = 2147483647
-MIN_INT = -2147483648
+MAX_INT = 9007199254740991
+MIN_INT = -9007199254740991
 
 
 class Int(Scalar):


### PR DESCRIPTION
Seems the comment uses the [MAX_SAFE_INTEGER](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER#description) which should be 2^53 - 1 instead of 2^32 - 1.

https://github.com/graphql/graphql-spec/issues/73

This might be platform dependent so switching to use `sys.maxsize` might be an alternative.

@syrusakbary 
 