### PR TITLE
Fix GraphQL-core dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ setup(
     keywords="api graphql protocol rest relay graphene",
     packages=find_packages(exclude=["examples*"]),
     install_requires=[
-        "graphql-core>=3.1.2,<4",
+        "graphql-core~=3.1.2",
         "graphql-relay>=3.0,<4",
         "aniso8601>=8,<10",
     ],


### PR DESCRIPTION
GraphQL-core released `3.2.0rc1` with some breaking changes and
1. We should be getting RC releases in our dependencies
2. It has breaking changes, so we shouldn't get 3.2.0 unless someone fixes it explicitly