### PR TITLE
Make tests work with GraphQL-core 3.2.0rc2

### DIFF
--- a/examples/starwars_relay/tests/test_objectidentification.py
+++ b/examples/starwars_relay/tests/test_objectidentification.py
@@ -9,7 +9,7 @@ client = Client(schema)
 
 
 def test_str_schema(snapshot):
-    snapshot.assert_match(str(schema))
+    snapshot.assert_match(str(schema).rstrip() + "\n")
 
 
 def test_correctly_fetches_id_name_rebels(snapshot):

--- a/graphene/relay/tests/test_node.py
+++ b/graphene/relay/tests/test_node.py
@@ -171,7 +171,7 @@ def test_node_field_only_lazy_type_wrong():
 
 
 def test_str_schema():
-    assert str(schema) == dedent(
+    assert str(schema).rstrip() + "\n" == dedent(
         '''
         schema {
           query: RootQuery

--- a/graphene/relay/tests/test_node_custom.py
+++ b/graphene/relay/tests/test_node_custom.py
@@ -54,7 +54,7 @@ graphql_schema = schema.graphql_schema
 
 
 def test_str_schema_correct():
-    assert str(schema) == dedent(
+    assert str(schema).rstrip() + "\n" == dedent(
         '''
         schema {
           query: RootQuery

--- a/graphene/types/schema.py
+++ b/graphene/types/schema.py
@@ -381,12 +381,7 @@ class TypeMap(dict):
             return default_type_resolver(root, info, return_type)
 
         if inspect.isclass(type_) and issubclass(type_, ObjectType):
-            graphql_type = self.get(type_._meta.name)
-            assert graphql_type, f"Can't find type {type_._meta.name} in schema"
-            assert (
-                graphql_type.graphene_type == type_
-            ), f"The type {type_} does not match with the associated graphene type {graphql_type.graphene_type}."
-            return graphql_type
+            return type_._meta.name
 
         return type_
 

--- a/graphene/types/tests/test_enum.py
+++ b/graphene/types/tests/test_enum.py
@@ -251,7 +251,7 @@ def test_enum_types():
 
     schema = Schema(query=Query)
 
-    assert str(schema) == dedent(
+    assert str(schema).rstrip() + "\n" == dedent(
         '''\
         type Query {
           color: Color!
@@ -345,10 +345,8 @@ def test_enum_resolver_invalid():
 
     results = schema.execute("query { color }")
     assert results.errors
-    assert (
-        results.errors[0].message
-        == "Expected a value of type 'Color' but received: 'BLACK'"
-    )
+    message = results.errors[0].message
+    assert "Expected" in message and "Color" in message and "BLACK" in message
 
 
 def test_field_enum_argument():

--- a/graphene/types/tests/test_schema.py
+++ b/graphene/types/tests/test_schema.py
@@ -43,7 +43,7 @@ def test_schema_get_type_error():
 
 def test_schema_str():
     schema = Schema(Query)
-    assert str(schema) == dedent(
+    assert str(schema).rstrip() + "\n" == dedent(
         """
         type Query {
           inner: MyOtherType

--- a/graphene/types/union.py
+++ b/graphene/types/union.py
@@ -72,4 +72,4 @@ class Union(UnmountedType, BaseType):
         from .objecttype import ObjectType  # NOQA
 
         if isinstance(instance, ObjectType):
-            return type(instance)
+            return instance._meta.name

--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ setup(
     keywords="api graphql protocol rest relay graphene",
     packages=find_packages(exclude=["examples*"]),
     install_requires=[
-        "graphql-core~=3.1.2",
+        "graphql-core>=3.1.2,<3.3",
         "graphql-relay>=3.0,<4",
         "aniso8601>=8,<10",
     ],


### PR DESCRIPTION
This fix aligns to some changes in GraphQL-core 3.2 which reflect changes in GraphQL.js 16:
- type resolvers must return only names
- doesn't print trailing newlines any more
- different wording of some error messages