### PR TITLE
Avoid ambiguity in graphene.Mutation docstring [documentation]

### DIFF
--- a/graphene/types/mutation.py
+++ b/graphene/types/mutation.py
@@ -29,21 +29,21 @@ class Mutation(ObjectType):
 
     .. code:: python
 
-        from graphene import Mutation, ObjectType, String, Boolean, Field
+        import graphene
 
-        class CreatePerson(Mutation):
+        class CreatePerson(graphene.Mutation):
             class Arguments:
-                name = String()
+                name = graphene.String()
 
-            ok = Boolean()
-            person = Field(Person)
+            ok = graphene.Boolean()
+            person = graphene.Field(Person)
 
             def mutate(parent, info, name):
                 person = Person(name=name)
                 ok = True
                 return CreatePerson(person=person, ok=ok)
 
-        class Mutation(ObjectType):
+        class Mutation(graphene.ObjectType):
             create_person = CreatePerson.Field()
 
     Meta class options (optional):


### PR DESCRIPTION
The code example in docstring starts with `from graphene import Mutation` and defines a `class Mutation` later. This definition would shadow previously imported name and (which is more important) confuses a reader about usage of this class — one need to keep in mind that previous usage of `Mutation` is imported from graphene and have not been overridden yet.

This PR changes an "import-from" statement to an "import" statement, so `graphene.Mutation` is referred explicitly. This approach seems to be consistent with other code examples in the docs (e. g. see https://docs.graphene-python.org/en/v2.1.9/types/mutations/).

Another option is to change name of example class Mutation to something more explicit (maybe SchemaMutation or RootMutation), but I'm not sure what name to choose.

Only docstring is updated, no code changes.