### PR TITLE
Sets default_value for argument to Undefined instead of None

### DIFF
--- a/examples/starwars_relay/tests/snapshots/snap_test_objectidentification.py
+++ b/examples/starwars_relay/tests/snapshots/snap_test_objectidentification.py
@@ -7,31 +7,52 @@ from snapshottest import Snapshot
 
 snapshots = Snapshot()
 
-snapshots["test_correctly_fetches_id_name_rebels 1"] = {
-    "data": {
-        "rebels": {"id": "RmFjdGlvbjox", "name": "Alliance to Restore the Republic"}
+snapshots['test_correctly_fetches_id_name_empire 1'] = {
+    'data': {
+        'empire': {
+            'id': 'RmFjdGlvbjoy',
+            'name': 'Galactic Empire'
+        }
     }
 }
 
-snapshots["test_correctly_refetches_rebels 1"] = {
-    "data": {"node": {"id": "RmFjdGlvbjox", "name": "Alliance to Restore the Republic"}}
+snapshots['test_correctly_fetches_id_name_rebels 1'] = {
+    'data': {
+        'rebels': {
+            'id': 'RmFjdGlvbjox',
+            'name': 'Alliance to Restore the Republic'
+        }
+    }
 }
 
-snapshots["test_correctly_fetches_id_name_empire 1"] = {
-    "data": {"empire": {"id": "RmFjdGlvbjoy", "name": "Galactic Empire"}}
+snapshots['test_correctly_refetches_empire 1'] = {
+    'data': {
+        'node': {
+            'id': 'RmFjdGlvbjoy',
+            'name': 'Galactic Empire'
+        }
+    }
 }
 
-snapshots["test_correctly_refetches_empire 1"] = {
-    "data": {"node": {"id": "RmFjdGlvbjoy", "name": "Galactic Empire"}}
+snapshots['test_correctly_refetches_rebels 1'] = {
+    'data': {
+        'node': {
+            'id': 'RmFjdGlvbjox',
+            'name': 'Alliance to Restore the Republic'
+        }
+    }
 }
 
-snapshots["test_correctly_refetches_xwing 1"] = {
-    "data": {"node": {"id": "U2hpcDox", "name": "X-Wing"}}
+snapshots['test_correctly_refetches_xwing 1'] = {
+    'data': {
+        'node': {
+            'id': 'U2hpcDox',
+            'name': 'X-Wing'
+        }
+    }
 }
 
-snapshots[
-    "test_str_schema 1"
-] = '''type Query {
+snapshots['test_str_schema 1'] = '''type Query {
   rebels: Faction
   empire: Faction
   node(
@@ -49,7 +70,7 @@ type Faction implements Node {
   name: String
 
   """The ships used by the faction."""
-  ships(before: String = null, after: String = null, first: Int = null, last: Int = null): ShipConnection
+  ships(before: String, after: String, first: Int, last: Int): ShipConnection
 }
 
 """An object with an ID"""

--- a/graphene/types/argument.py
+++ b/graphene/types/argument.py
@@ -4,6 +4,7 @@ from .dynamic import Dynamic
 from .mountedtype import MountedType
 from .structures import NonNull
 from .utils import get_type
+from graphql import Undefined
 
 
 class Argument(MountedType):
@@ -41,7 +42,7 @@ class Argument(MountedType):
     def __init__(
         self,
         type_,
-        default_value=None,
+        default_value=Undefined,
         description=None,
         name=None,
         required=False,

--- a/graphene/types/tests/test_query.py
+++ b/graphene/types/tests/test_query.py
@@ -229,11 +229,11 @@ def test_query_arguments():
 
     result = test_schema.execute("{ test }", None)
     assert not result.errors
-    assert result.data == {"test": '[null,{"a_str":null,"a_int":null}]'}
+    assert result.data == {"test": "[null,{}]"}
 
     result = test_schema.execute('{ test(aStr: "String!") }', "Source!")
     assert not result.errors
-    assert result.data == {"test": '["Source!",{"a_str":"String!","a_int":null}]'}
+    assert result.data == {"test": '["Source!",{"a_str":"String!"}]'}
 
     result = test_schema.execute('{ test(aInt: -123, aStr: "String!") }', "Source!")
     assert not result.errors
@@ -241,6 +241,7 @@ def test_query_arguments():
         {"test": '["Source!",{"a_str":"String!","a_int":-123}]'},
         {"test": '["Source!",{"a_int":-123,"a_str":"String!"}]'},
     ]
+
 
 
 def test_query_input_field():
@@ -258,7 +259,7 @@ def test_query_input_field():
 
     result = test_schema.execute("{ test }", None)
     assert not result.errors
-    assert result.data == {"test": '[null,{"a_input":null}]'}
+    assert result.data == {"test": "[null,{}]"}
 
     result = test_schema.execute('{ test(aInput: {aField: "String!"} ) }', "Source!")
     assert not result.errors

--- a/graphene/types/tests/test_type_map.py
+++ b/graphene/types/tests/test_type_map.py
@@ -244,7 +244,7 @@ def test_objecttype_camelcase():
     foo_field = fields["fooBar"]
     assert isinstance(foo_field, GraphQLField)
     assert foo_field.args == {
-        "barFoo": GraphQLArgument(GraphQLString, default_value=None, out_name="bar_foo")
+        "barFoo": GraphQLArgument(GraphQLString, out_name="bar_foo")
     }
 
 
@@ -267,7 +267,7 @@ def test_objecttype_camelcase_disabled():
     assert isinstance(foo_field, GraphQLField)
     assert foo_field.args == {
         "bar_foo": GraphQLArgument(
-            GraphQLString, default_value=None, out_name="bar_foo"
+            GraphQLString, out_name="bar_foo"
         )
     }
 


### PR DESCRIPTION
fixes #1398 .
The tests' asserts are now matching the v2 ones, which I believe match the expected behaviour described here:

https://docs.graphene-python.org/en/latest/types/objecttypes/#graphql-argument-defaults