### PR TITLE
Highlight .get in backticks

### DIFF
--- a/docs/types/enums.rst
+++ b/docs/types/enums.rst
@@ -86,7 +86,7 @@ In the Python ``Enum`` implementation you can access a member by initing the Enu
     assert Color(1) == Color.RED
 
 
-However, in Graphene ``Enum`` you need to call get to have the same effect:
+However, in Graphene ``Enum`` you need to call `.get` to have the same effect:
 
 .. code:: python
 


### PR DESCRIPTION
When I first read through the documentation twice, it took me two tries and looking very hard to find out the difference b/w the two. The background highlight using backticks would be helpful in this case.