### PR TITLE
docs: Fix a few typos

### DIFF
--- a/UPGRADE-v1.0.md
+++ b/UPGRADE-v1.0.md
@@ -153,7 +153,7 @@ class Query(ObjectType):
 ```
 
 Also, if you wanted to create an `ObjectType` that implements `Node`, you have to do it
-explicity.
+explicitly.
 
 ## Django
 

--- a/UPGRADE-v2.0.md
+++ b/UPGRADE-v2.0.md
@@ -123,7 +123,7 @@ def resolve_my_field(root, info, my_arg):
     return ...
 ```
 
-**PS.: Take care with receiving args like `my_arg` as above. This doesn't work for optional (non-required) arguments as stantard `Connection`'s arguments (first, last, after, before).**
+**PS.: Take care with receiving args like `my_arg` as above. This doesn't work for optional (non-required) arguments as standard `Connection`'s arguments (first, last, after, before).**
 You may need something like this:
 
 ```python

--- a/docs/execution/fileuploading.rst
+++ b/docs/execution/fileuploading.rst
@@ -4,5 +4,5 @@ File uploading
 File uploading is not part of the official GraphQL spec yet and is not natively
 implemented in Graphene.
 
-If your server needs to support file uploading then you can use the libary: `graphene-file-upload <https://github.com/lmcgartland/graphene-file-upload>`_ which enhances Graphene to add file
+If your server needs to support file uploading then you can use the library: `graphene-file-upload <https://github.com/lmcgartland/graphene-file-upload>`_ which enhances Graphene to add file
 uploads and conforms to the unoffical GraphQL `multipart request spec <https://github.com/jaydenseric/graphql-multipart-request-spec>`_.


### PR DESCRIPTION
There are small typos in:
- UPGRADE-v1.0.md
- UPGRADE-v2.0.md
- docs/execution/fileuploading.rst

Fixes:
- Should read `standard` rather than `stantard`.
- Should read `library` rather than `libary`.
- Should read `explicitly` rather than `explicity`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md