### PR TITLE
Fix Test Failure due to #1304

### DIFF
--- a/graphene/types/datetime.py
+++ b/graphene/types/datetime.py
@@ -73,7 +73,6 @@ class DateTime(Scalar):
             )
         return cls.parse_value(node.value)
 
-
     @staticmethod
     def parse_value(value):
         if isinstance(value, datetime.datetime):

--- a/graphene/types/datetime.py
+++ b/graphene/types/datetime.py
@@ -65,6 +65,15 @@ class DateTime(Scalar):
             )
         return cls.parse_value(node.value)
 
+    @classmethod
+    def parse_literal_codecov_test(cls, node, _variables=None):
+        if not isinstance(node, StringValueNode):
+            raise GraphQLError(
+                f"DateTime cannot represent non-string value: {print_ast(node)}"
+            )
+        return cls.parse_value(node.value)
+
+
     @staticmethod
     def parse_value(value):
         if isinstance(value, datetime.datetime):

--- a/graphene/types/datetime.py
+++ b/graphene/types/datetime.py
@@ -66,7 +66,7 @@ class DateTime(Scalar):
         return cls.parse_value(node.value)
 
     @classmethod
-    def parse_literal_codecov_test(cls, node, _variables=None):
+    def parse_literal_codecov_v3_test(cls, node, _variables=None):
         if not isinstance(node, StringValueNode):
             raise GraphQLError(
                 f"DateTime cannot represent non-string value: {print_ast(node)}"

--- a/graphene/types/tests/test_type_map.py
+++ b/graphene/types/tests/test_type_map.py
@@ -303,6 +303,7 @@ def test_interface_with_interfaces():
         bar = String()
 
     type_map = create_type_map([FooInterface, BarInterface])
+
     assert "FooInterface" in type_map
     foo_graphql_type = type_map["FooInterface"]
     assert isinstance(foo_graphql_type, GraphQLInterfaceType)
@@ -317,5 +318,4 @@ def test_interface_with_interfaces():
     assert list(fields) == ["foo", "bar"]
     assert isinstance(fields["foo"], GraphQLField)
     assert isinstance(fields["bar"], GraphQLField)
-
-    assert bar_graphql_type.interfaces == [foo_graphql_type]
+    assert list(bar_graphql_type.interfaces) == list([foo_graphql_type])


### PR DESCRIPTION
`assert bar_graphql_type.interfaces == [foo_graphql_type]` failed only on tox, because .interfaces was a tuple instead of a list. Error didn't occur using just pytest. Fixed by explicitly 
converting both to list.
