### PR TITLE
Add copy function for GrapheneGraphQLType

### DIFF
--- a/graphene/types/definitions.py
+++ b/graphene/types/definitions.py
@@ -20,6 +20,11 @@ class GrapheneGraphQLType:
         self.graphene_type = kwargs.pop("graphene_type")
         super(GrapheneGraphQLType, self).__init__(*args, **kwargs)
 
+    def __copy__(self):
+        result = GrapheneGraphQLType(graphene_type=self.graphene_type)
+        result.__dict__.update(self.__dict__)
+        return result
+
 
 class GrapheneInterfaceType(GrapheneGraphQLType, GraphQLInterfaceType):
     pass

--- a/graphene/types/tests/test_definition.py
+++ b/graphene/types/tests/test_definition.py
@@ -1,4 +1,7 @@
+import copy
+
 from ..argument import Argument
+from ..definitions import GrapheneGraphQLType
 from ..enum import Enum
 from ..field import Field
 from ..inputfield import InputField
@@ -312,3 +315,15 @@ def test_does_not_mutate_passed_field_definitions():
         pass
 
     assert TestInputObject1._meta.fields == TestInputObject2._meta.fields
+
+def test_graphene_graphql_type_can_be_copied():
+    class Query(ObjectType):
+        field = String()
+
+        def resolve_field(self, info):
+            return ''
+
+    schema = Schema(query=Query)
+    query_type_copy = copy.copy(schema.graphql_schema.query_type)
+    assert query_type_copy.__dict__ == schema.graphql_schema.query_type.__dict__
+    assert isinstance(schema.graphql_schema.query_type, GrapheneGraphQLType)

--- a/graphene/types/tests/test_definition.py
+++ b/graphene/types/tests/test_definition.py
@@ -316,12 +316,13 @@ def test_does_not_mutate_passed_field_definitions():
 
     assert TestInputObject1._meta.fields == TestInputObject2._meta.fields
 
+
 def test_graphene_graphql_type_can_be_copied():
     class Query(ObjectType):
         field = String()
 
         def resolve_field(self, info):
-            return ''
+            return ""
 
     schema = Schema(query=Query)
     query_type_copy = copy.copy(schema.graphql_schema.query_type)


### PR DESCRIPTION
Fixes https://github.com/graphql-python/graphene/issues/1333

First found in a Django project while upgrading to graphene 3. Django's `setUpTestData` tries to create a copy of a GrapheneGraphQLType and raises a `KeyError: 'graphene_type'`. This doesn't happen in graphene 2.1.8