### PR TITLE
AttributeError: Type "get_type" not found in the Schema

### DIFF
--- a/graphene/types/schema.py
+++ b/graphene/types/schema.py
@@ -452,6 +452,9 @@ class Schema:
             return _type.graphene_type
         return _type
 
+    def get_type(self, name):
+        return self.graphql_schema.type_map.get(name)
+    
     def lazy(self, _type):
         return lambda: self.get_type(_type)
 

--- a/graphene/types/schema.py
+++ b/graphene/types/schema.py
@@ -453,8 +453,12 @@ class Schema:
         return _type
 
     def get_type(self, name):
-        return self.graphql_schema.type_map.get(name)
-    
+        '''
+        This will actually return a `GraphQLObjectType` of type `GrapheneObjectType` from graphql-core, not a graphene ObjectType.
+            These two are fundamentally different classes. That's the reason why your test is failing. You'd need to return the Graphene type here.
+        '''
+        return self.graphql_schema.type_map.get(name).graphene_type
+
     def lazy(self, _type):
         return lambda: self.get_type(_type)
 

--- a/graphene/types/schema.py
+++ b/graphene/types/schema.py
@@ -453,7 +453,7 @@ class Schema:
         return _type
 
     def get_type(self, name):
-        return self.graphql_schema.type_map.get(name).graphene_type
+        return self.graphql_schema.type_map.get(name)
 
     def lazy(self, _type):
         return lambda: self.get_type(_type)

--- a/graphene/types/schema.py
+++ b/graphene/types/schema.py
@@ -453,10 +453,6 @@ class Schema:
         return _type
 
     def get_type(self, name):
-        """
-        This will actually return a `GraphQLObjectType` of type `GrapheneObjectType` from graphql-core, not a graphene ObjectType.
-            These two are fundamentally different classes. That's the reason why your test is failing. You'd need to return the Graphene type here.
-        """
         return self.graphql_schema.type_map.get(name).graphene_type
 
     def lazy(self, _type):

--- a/graphene/types/schema.py
+++ b/graphene/types/schema.py
@@ -453,10 +453,10 @@ class Schema:
         return _type
 
     def get_type(self, name):
-        '''
+        """
         This will actually return a `GraphQLObjectType` of type `GrapheneObjectType` from graphql-core, not a graphene ObjectType.
             These two are fundamentally different classes. That's the reason why your test is failing. You'd need to return the Graphene type here.
-        '''
+        """
         return self.graphql_schema.type_map.get(name).graphene_type
 
     def lazy(self, _type):

--- a/graphene/types/tests/test_schema.py
+++ b/graphene/types/tests/test_schema.py
@@ -32,7 +32,7 @@ def test_schema_get_type():
     schema = Schema(Query)
     assert schema.Query == Query
     assert schema.MyOtherType == MyOtherType
-    assert schema.get_type('MyOtherType') == MyOtherType
+    assert schema.get_type("MyOtherType") == MyOtherType
 
 
 

--- a/graphene/types/tests/test_schema.py
+++ b/graphene/types/tests/test_schema.py
@@ -32,6 +32,7 @@ def test_schema_get_type():
     schema = Schema(Query)
     assert schema.Query == Query
     assert schema.MyOtherType == MyOtherType
+    schema.get_type('MyOtherType')
 
 
 def test_schema_get_type_error():

--- a/graphene/types/tests/test_schema.py
+++ b/graphene/types/tests/test_schema.py
@@ -32,7 +32,8 @@ def test_schema_get_type():
     schema = Schema(Query)
     assert schema.Query == Query
     assert schema.MyOtherType == MyOtherType
-    schema.get_type('MyOtherType')
+    assert schema.get_type('MyOtherType') == MyOtherType
+
 
 
 def test_schema_get_type_error():

--- a/graphene/types/tests/test_schema.py
+++ b/graphene/types/tests/test_schema.py
@@ -32,7 +32,10 @@ def test_schema_get_type():
     schema = Schema(Query)
     assert schema.Query == Query
     assert schema.MyOtherType == MyOtherType
-    assert schema.get_type("MyOtherType") == MyOtherType
+    name = "MyOtherType"
+    assert isinstance(schema.get_type(name), GraphQLObjectType)
+    assert schema.get_type(name).name == name
+    assert schema.get_type(name).graphene_type == MyOtherType
 
 
 def test_schema_get_type_error():

--- a/graphene/types/tests/test_schema.py
+++ b/graphene/types/tests/test_schema.py
@@ -35,7 +35,6 @@ def test_schema_get_type():
     assert schema.get_type("MyOtherType") == MyOtherType
 
 
-
 def test_schema_get_type_error():
     schema = Schema(Query)
     with raises(AttributeError) as exc_info:


### PR DESCRIPTION
```
    relay.Node.get_node_from_global_id(info, g_id) for g_id in global_id
  File "/home/jm/pycharm_projects/x/venv_3_10_7/lib/python3.10/site-packages/graphene/relay/node.py", line 98, in get_node_from_global_id
    graphene_type = info.schema.get_type(_type)
  File "/home/jm/pycharm_projects/xvenv_3_10_7/lib/python3.10/site-packages/graphene/types/schema.py", line 451, in __getattr__
    if isinstance(_type, GrapheneGraphQLType):
AttributeError: Type "get_type" not found in the Schema
```

graphene==3.1.1
python 3.10.7