### PR TITLE
Disambiguate argument name in quickstart docs

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -37,12 +37,12 @@ An example in Graphene
 
 Let’s build a basic GraphQL schema to say "hello" and "goodbye" in Graphene.
 
-When we send a **Query** requesting only one **Field**, ``hello``, and specify a value for the ``name`` **Argument**...
+When we send a **Query** requesting only one **Field**, ``hello``, and specify a value for the ``firstName`` **Argument**...
 
 .. code::
 
     {
-      hello(name: "friend")
+      hello(firstName: "friend")
     }
 
 ...we would expect the following Response containing only the data requested (the ``goodbye`` field is not resolved).
@@ -79,14 +79,15 @@ In Graphene, we can define a simple schema using the following code:
     from graphene import ObjectType, String, Schema
 
     class Query(ObjectType):
-        # this defines a Field `hello` in our Schema with a single Argument `name`
-        hello = String(name=String(default_value="stranger"))
+        # this defines a Field `hello` in our Schema with a single Argument `first_name`
+        # By default, the argument name will automatically be camel-based into firstName in the generated schema
+        hello = String(first_name=String(default_value="stranger"))
         goodbye = String()
 
         # our Resolver method takes the GraphQL context (root, info) as well as
-        # Argument (name) for the Field and returns data for the query Response
-        def resolve_hello(root, info, name):
-            return f'Hello {name}!'
+        # Argument (first_name) for the Field and returns data for the query Response
+        def resolve_hello(root, info, first_name):
+            return f'Hello {first_name}!'
 
         def resolve_goodbye(root, info):
             return 'See ya!'
@@ -110,7 +111,7 @@ In the `GraphQL Schema Definition Language`_, we could describe the fields defin
 .. code::
 
     type Query {
-      hello(name: String = "stranger"): String
+      hello(firstName: String = "stranger"): String
       goodbye: String
     }
 
@@ -130,7 +131,7 @@ Then we can start querying our **Schema** by passing a GraphQL query string to `
     # "Hello stranger!"
 
     # or passing the argument in the query
-    query_with_argument = '{ hello(name: "GraphQL") }'
+    query_with_argument = '{ hello(firstName: "GraphQL") }'
     result = schema.execute(query_with_argument)
     print(result.data['hello'])
     # "Hello GraphQL!"


### PR DESCRIPTION
As shown in #1230, the documentation has caused some confusion among new users because of `name` being simultaneously used as a keyword and as a field name. Given that most people will initially rely on the quickstart documentation, the `name` field name has been changed to something that's more obviously not a keyword.

Fixes #1230 