### PR TITLE
Clarify execution order in middleware docs

### DIFF
--- a/docs/execution/middleware.rst
+++ b/docs/execution/middleware.rst
@@ -41,6 +41,8 @@ And then execute it with:
 
     result = schema.execute('THE QUERY', middleware=[AuthorizationMiddleware()])
 
+If the ``middleware`` argument includes multiple middlewares,
+these middlewares will be executed bottom-up, i.e. from last to first.
 
 Functional example
 ------------------


### PR DESCRIPTION
This PR adds a note to the middleware documentation noting the last-to-first execution order for middlewares, since #1385 indicates that some people were surprised by this behavior.

Fixes #1385