### PR TITLE
Remove unnecessary dependency on 'promise' library

### DIFF
--- a/graphene/relay/tests/test_mutation_async.py
+++ b/graphene/relay/tests/test_mutation_async.py
@@ -3,6 +3,7 @@ from pytest import mark
 from graphene.types import ID, Field, ObjectType, Schema
 from graphene.types.scalars import String
 from graphene.relay.mutation import ClientIDMutation
+from graphene.test import Client
 
 
 class SharedFields(object):
@@ -61,24 +62,27 @@ class Mutation(ObjectType):
 
 
 schema = Schema(query=RootQuery, mutation=Mutation)
+client = Client(schema)
 
 
 @mark.asyncio
 async def test_node_query_promise():
-    executed = await schema.execute_async(
+    executed = await client.execute_async(
         'mutation a { sayPromise(input: {what:"hello", clientMutationId:"1"}) { phrase } }'
     )
-    assert not executed.errors
-    assert executed.data == {"sayPromise": {"phrase": "hello"}}
+    assert isinstance(executed, dict)
+    assert "errors" not in executed
+    assert executed["data"] == {"sayPromise": {"phrase": "hello"}}
 
 
 @mark.asyncio
 async def test_edge_query():
-    executed = await schema.execute_async(
+    executed = await client.execute_async(
         'mutation a { other(input: {clientMutationId:"1"}) { clientMutationId, myNodeEdge { cursor node { name }} } }'
     )
-    assert not executed.errors
-    assert dict(executed.data) == {
+    assert isinstance(executed, dict)
+    assert "errors" not in executed
+    assert executed["data"] == {
         "other": {
             "clientMutationId": "1",
             "myNodeEdge": {"cursor": "1", "node": {"name": "name"}},

--- a/graphene/test/__init__.py
+++ b/graphene/test/__init__.py
@@ -1,4 +1,3 @@
-from promise import Promise, is_thenable
 from graphql.error import GraphQLError
 
 from graphene.types.schema import Schema
@@ -31,7 +30,10 @@ class Client:
 
     def execute(self, *args, **kwargs):
         executed = self.schema.execute(*args, **dict(self.execute_options, **kwargs))
-        if is_thenable(executed):
-            return Promise.resolve(executed).then(self.format_result)
+        return self.format_result(executed)
 
+    async def execute_async(self, *args, **kwargs):
+        executed = await self.schema.execute_async(
+            *args, **dict(self.execute_options, **kwargs)
+        )
         return self.format_result(executed)

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,6 @@ tests_require = [
     "pytest-asyncio>=0.16,<2",
     "snapshottest>=0.6,<1",
     "coveralls>=3.3,<4",
-    "promise>=2.3,<3",
     "mock>=4,<5",
     "pytz==2022.1",
     "iso8601>=1,<2",


### PR DESCRIPTION
Previously, installing graphene and trying to do `from graphene.test import Client` as recommended in the docs caused an `ImportError`, as the 'promise' library is imported but only listed as a requirement in the 'test' section of the setup.py file.

Based on #1297 which appears to be inactive. Fixes #1296.