### PR TITLE
Do not interpret Enum members called 'description' as description properties

### DIFF
--- a/graphene/types/schema.py
+++ b/graphene/types/schema.py
@@ -1,3 +1,4 @@
+from enum import Enum as PyEnum
 import inspect
 from functools import partial
 
@@ -169,10 +170,16 @@ class TypeMap(dict):
         values = {}
         for name, value in graphene_type._meta.enum.__members__.items():
             description = getattr(value, "description", None)
-            deprecation_reason = getattr(value, "deprecation_reason", None)
+            # if the "description" attribute is an Enum, it is likely an enum member
+            # called description, not a description property
+            if isinstance(description, PyEnum):
+                description = None
             if not description and callable(graphene_type._meta.description):
                 description = graphene_type._meta.description(value)
 
+            deprecation_reason = getattr(value, "deprecation_reason", None)
+            if isinstance(deprecation_reason, PyEnum):
+                deprecation_reason = None
             if not deprecation_reason and callable(
                 graphene_type._meta.deprecation_reason
             ):


### PR DESCRIPTION
This is a workaround for `TypeError`s being raised when initialising schemas with Enum members named `description` or `deprecation_reason`.

It is still not ideal as you can't have an enum with both a "description" member and a description property. Fixing this would require some more thought though. Potentially we could allow something like `__description__` as an alternative way of naming the description property in cases where it conflicts with one of the members.

Fixes #1321 (ish)