### PR TITLE
Correct the module name of custom scalar example in documentation

### DIFF
--- a/docs/types/scalars.rst
+++ b/docs/types/scalars.rst
@@ -271,7 +271,7 @@ The following is an example for creating a DateTime scalar:
 
         @staticmethod
         def parse_literal(node, _variables=None):
-            if isinstance(node, ast.StringValue):
+            if isinstance(node, ast.StringValueNode):
                 return datetime.datetime.strptime(
                     node.value, "%Y-%m-%dT%H:%M:%S.%f")
 


### PR DESCRIPTION
Update documentation because `graphql.language.ast.StringValue` in V2 has been renamed to `graphql.language.ast.StringValueNode` in V3.