### PR TITLE
Remove prerelease notice

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,12 +1,6 @@
 Graphene
 ========
 
-------------
-
-The documentation below is for the ``dev`` (prerelease) version of Graphene. To view the documentation for the latest stable Graphene version go to the `v2 docs <https://docs.graphene-python.org/en/stable/>`_.
-
-------------
-
 Contents:
 
 .. toctree::


### PR DESCRIPTION
I'm assuming v3 is no longer a prerelease and this notice should be removed 🤔  (the v2 link just takes you to the same docs so 🤷🏻‍♂️ )