### PR TITLE
docs: update sphinx to the latest version

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,9 +36,6 @@ Graphene has multiple integrations with different frameworks:
 | SQLAlchemy        | `graphene-sqlalchemy <https://git               |
 |                   | hub.com/graphql-python/graphene-sqlalchemy/>`__ |
 +-------------------+-------------------------------------------------+
-| Google App Engine | `graphene-gae <http                             |
-|                   | s://github.com/graphql-python/graphene-gae/>`__ |
-+-------------------+-------------------------------------------------+
 
 Also, Graphene is fully compatible with the GraphQL spec, working
 seamlessly with all GraphQL clients, such as

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -92,7 +92,7 @@ Execution Metadata
 
 .. autoclass:: graphene.Context
 
-.. autoclass:: graphql.execution.base.ExecutionResult
+.. autoclass:: graphql.ExecutionResult
 
 .. Relay
 .. -----

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -82,7 +82,7 @@ release = "1.0"
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+# language = None
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -456,5 +456,4 @@ intersphinx_mapping = {
         "http://docs.graphene-python.org/projects/sqlalchemy/en/latest/",
         None,
     ),
-    "graphene_gae": ("http://docs.graphene-python.org/projects/gae/en/latest/", None),
 }

--- a/docs/execution/queryvalidation.rst
+++ b/docs/execution/queryvalidation.rst
@@ -1,5 +1,5 @@
 Query Validation
-==========
+================
 GraphQL uses query validators to check if Query AST is valid and can be executed. Every GraphQL server implements
 standard query validators. For example, there is an validator that tests if queried field exists on queried type, that
 makes query fail with "Cannot query field on type" error if it doesn't.
@@ -8,7 +8,7 @@ To help with common use cases, graphene provides a few validation rules out of t
 
 
 Depth limit Validator
------------------
+---------------------
 The depth limit validator helps to prevent execution of malicious
 queries. It takes in the following arguments.
 
@@ -17,7 +17,7 @@ queries. It takes in the following arguments.
 - ``callback`` Called each time validation runs. Receives an Object which is a map of the depths for each operation.
 
 Usage
--------
+-----
 
 Here is how you would implement depth-limiting on your schema.
 
@@ -54,7 +54,7 @@ the disable introspection validation rule ensures that your schema cannot be int
 This is a useful security measure in production environments.
 
 Usage
--------
+-----
 
 Here is how you would disable introspection for your schema.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -21,7 +21,6 @@ Integrations
 * `Graphene-Django <http://docs.graphene-python.org/projects/django/en/latest/>`_ (`source <https://github.com/graphql-python/graphene-django/>`_)
 * Flask-Graphql (`source <https://github.com/graphql-python/flask-graphql>`_)
 * `Graphene-SQLAlchemy <http://docs.graphene-python.org/projects/sqlalchemy/en/latest/>`_ (`source <https://github.com/graphql-python/graphene-sqlalchemy/>`_)
-* `Graphene-GAE <http://docs.graphene-python.org/projects/gae/en/latest/>`_ (`source <https://github.com/graphql-python/graphene-gae/>`_)
 * `Graphene-Mongo <http://graphene-mongo.readthedocs.io/en/latest/>`_ (`source <https://github.com/graphql-python/graphene-mongo>`_)
 * `Starlette <https://www.starlette.io/graphql/>`_ (`source <https://github.com/encode/starlette>`_)
 * `FastAPI <https://fastapi.tiangolo.com/advanced/graphql/>`_ (`source <https://github.com/tiangolo/fastapi>`_)

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 # Required library
-Sphinx==1.5.3
-sphinx-autobuild==0.7.1
+Sphinx==6.1.3
+sphinx-autobuild==2021.3.14
 # Docs template
 http://graphene-python.org/sphinx_graphene_theme.zip


### PR DESCRIPTION
Hello,
I first wanted to contribute to the graphene docs, but I don't manage to install it locally due to the sphinx version.

I create this MR to update the docs to the latest version of sphinx today.

Here is my changes :

- Deps : update [Sphinx](https://pypi.org/project/Sphinx/) to 6.1.3 
- Deps : update [ sphinx-autobuild](https://pypi.org/project/sphinx-autobuild/) to 2021.3.14
- Conf : remove `language = None` line to avoid warning
- Deps : update `graphql.execution.base.ExecutionResult` to `graphql.ExecutionResult` as it is imported in the code files

I still get some warnings about duplicate or missing fields, more commits will follow.