### PR TITLE
Default enum description to "An enumeration."

### DIFF
--- a/graphene/types/enum.py
+++ b/graphene/types/enum.py
@@ -63,7 +63,7 @@ class EnumMeta(SubclassWithMeta_Meta):
         cls, enum, name=None, description=None, deprecation_reason=None
     ):  # noqa: N805
         name = name or enum.__name__
-        description = description or enum.__doc__
+        description = description or "An enumeration."
         meta_dict = {
             "enum": enum,
             "description": description,

--- a/graphene/types/enum.py
+++ b/graphene/types/enum.py
@@ -63,7 +63,7 @@ class EnumMeta(SubclassWithMeta_Meta):
         cls, enum, name=None, description=None, deprecation_reason=None
     ):  # noqa: N805
         name = name or enum.__name__
-        description = description or "An enumeration."
+        description = description or enum.__doc__ or "An enumeration."
         meta_dict = {
             "enum": enum,
             "description": description,

--- a/graphene/types/tests/test_enum.py
+++ b/graphene/types/tests/test_enum.py
@@ -64,6 +64,19 @@ def test_enum_from_builtin_enum():
     assert RGB.GREEN
     assert RGB.BLUE
 
+def test_enum_custom_description_in_constructor():
+    description = "An enumeration, but with a custom description"
+    RGB = Enum(
+        "RGB",
+        "RED,GREEN,BLUE",
+        description=description,
+    )
+    assert RGB._meta.description == description
+
+
+def test_enum_from_python3_enum_uses_default_builtin_doc():
+    RGB = Enum("RGB", "RED,GREEN,BLUE")
+    assert RGB._meta.description == "An enumeration."
 
 def test_enum_from_builtin_enum_accepts_lambda_description():
     def custom_description(value):

--- a/graphene/types/tests/test_enum.py
+++ b/graphene/types/tests/test_enum.py
@@ -79,6 +79,7 @@ def test_enum_from_python3_enum_uses_default_builtin_doc():
     RGB = Enum("RGB", "RED,GREEN,BLUE")
     assert RGB._meta.description == "An enumeration."
 
+
 def test_enum_from_builtin_enum_accepts_lambda_description():
     def custom_description(value):
         if not value:

--- a/graphene/types/tests/test_enum.py
+++ b/graphene/types/tests/test_enum.py
@@ -64,6 +64,7 @@ def test_enum_from_builtin_enum():
     assert RGB.GREEN
     assert RGB.BLUE
 
+
 def test_enum_custom_description_in_constructor():
     description = "An enumeration, but with a custom description"
     RGB = Enum(


### PR DESCRIPTION
Default enum description to "An enumeration." string as opposed to trying to read `enum.__doc__` as it appears to be not set to default enum class doc in python 3.11