### PR TITLE
fix: Use `typing.TYPE_CHECKING` to provide generalized way

### DIFF
--- a/graphene/types/inputobjecttype.py
+++ b/graphene/types/inputobjecttype.py
@@ -1,11 +1,12 @@
+from typing import TYPE_CHECKING
+
 from .base import BaseOptions, BaseType
 from .inputfield import InputField
 from .unmountedtype import UnmountedType
 from .utils import yank_fields_from_attrs
 
-# For static type checking with Mypy
-MYPY = False
-if MYPY:
+# For static type checking with type checker
+if TYPE_CHECKING:
     from typing import Dict, Callable  # NOQA
 
 

--- a/graphene/types/interface.py
+++ b/graphene/types/interface.py
@@ -1,10 +1,11 @@
+from typing import TYPE_CHECKING
+
 from .base import BaseOptions, BaseType
 from .field import Field
 from .utils import yank_fields_from_attrs
 
-# For static type checking with Mypy
-MYPY = False
-if MYPY:
+# For static type checking with type checker
+if TYPE_CHECKING:
     from typing import Dict, Iterable, Type  # NOQA
 
 

--- a/graphene/types/mutation.py
+++ b/graphene/types/mutation.py
@@ -1,3 +1,5 @@
+from typing import TYPE_CHECKING
+
 from ..utils.deprecated import warn_deprecation
 from ..utils.get_unbound_function import get_unbound_function
 from ..utils.props import props
@@ -6,9 +8,8 @@ from .objecttype import ObjectType, ObjectTypeOptions
 from .utils import yank_fields_from_attrs
 from .interface import Interface
 
-# For static type checking with Mypy
-MYPY = False
-if MYPY:
+# For static type checking with type checker
+if TYPE_CHECKING:
     from .argument import Argument  # NOQA
     from typing import Dict, Type, Callable, Iterable  # NOQA
 

--- a/graphene/types/objecttype.py
+++ b/graphene/types/objecttype.py
@@ -1,3 +1,5 @@
+from typing import TYPE_CHECKING
+
 from .base import BaseOptions, BaseType, BaseTypeMeta
 from .field import Field
 from .interface import Interface
@@ -7,9 +9,8 @@ try:
     from dataclasses import make_dataclass, field
 except ImportError:
     from ..pyutils.dataclasses import make_dataclass, field  # type: ignore
-# For static type checking with Mypy
-MYPY = False
-if MYPY:
+# For static type checking with type checker
+if TYPE_CHECKING:
     from typing import Dict, Iterable, Type  # NOQA
 
 

--- a/graphene/types/union.py
+++ b/graphene/types/union.py
@@ -1,9 +1,10 @@
+from typing import TYPE_CHECKING
+
 from .base import BaseOptions, BaseType
 from .unmountedtype import UnmountedType
 
-# For static type checking with Mypy
-MYPY = False
-if MYPY:
+# For static type checking with type checker
+if TYPE_CHECKING:
     from .objecttype import ObjectType  # NOQA
     from typing import Iterable, Type  # NOQA
 


### PR DESCRIPTION
Hello graphene!

I found that the code base is using `MYPY` as a constant to tell whether a type checker is running.

According to the [mypy docs](https://mypy.readthedocs.io/en/stable/runtime_troubles.html#typing-type-checking), however, `mypy` introduces a more commonly used constant: `typing.TYPE_CHECKING`. So I'd like to suggest using this rather than `MYPY`.

As `typing.TYPE_CHECKING` has been added since Python 3.5.2 and `graphene` supports from Python 3.6, there would be no problem with backporting.

Reference:
- https://docs.python.org/ko/3/library/typing.html#typing.TYPE_CHECKING
