### PR TITLE
types: add option for strict connection types

### DIFF
--- a/graphene/relay/connection.py
+++ b/graphene/relay/connection.py
@@ -22,8 +22,8 @@ def get_edge_class(
 
     class EdgeBase:
         node = Field(
-            NonNull(_node) if strict_types else _node, 
-            description="The item at the end of the edge"
+            NonNull(_node) if strict_types else _node,
+            description="The item at the end of the edge",
         )
         cursor = String(required=True, description="A cursor for use in pagination")
 

--- a/graphene/relay/connection.py
+++ b/graphene/relay/connection.py
@@ -13,12 +13,12 @@ from .node import is_node, AbstractNode
 
 
 def get_edge_class(
-    connection_class: Type["Connection"], _node: Type[AbstractNode], base_name: str
+    connection_class: Type["Connection"], _node: Type[AbstractNode], base_name: str, strict_types: bool = False
 ):
     edge_class = getattr(connection_class, "Edge", None)
 
     class EdgeBase:
-        node = Field(_node, description="The item at the end of the edge")
+        node = Field(NonNull(_node) if strict_types else _node, description="The item at the end of the edge")
         cursor = String(required=True, description="A cursor for use in pagination")
 
     class EdgeMeta:
@@ -83,7 +83,7 @@ class Connection(ObjectType):
         abstract = True
 
     @classmethod
-    def __init_subclass_with_meta__(cls, node=None, name=None, _meta=None, **options):
+    def __init_subclass_with_meta__(cls, node=None, name=None, strict_types=False, _meta=None, **options):
         if not _meta:
             _meta = ConnectionOptions(cls)
         assert node, f"You have to provide a node in {cls.__name__}.Meta"
@@ -111,10 +111,10 @@ class Connection(ObjectType):
             )
 
         if "edges" not in _meta.fields:
-            edge_class = get_edge_class(cls, node, base_name)  # type: ignore
+            edge_class = get_edge_class(cls, node, base_name, strict_types)  # type: ignore
             cls.Edge = edge_class
             _meta.fields["edges"] = Field(
-                NonNull(List(edge_class)),
+                NonNull(List(NonNull(edge_class) if strict_types else edge_class)),
                 description="Contains the nodes in this connection.",
             )
 

--- a/graphene/relay/connection.py
+++ b/graphene/relay/connection.py
@@ -13,12 +13,18 @@ from .node import is_node, AbstractNode
 
 
 def get_edge_class(
-    connection_class: Type["Connection"], _node: Type[AbstractNode], base_name: str, strict_types: bool = False
+    connection_class: Type["Connection"],
+    _node: Type[AbstractNode],
+    base_name: str,
+    strict_types: bool = False,
 ):
     edge_class = getattr(connection_class, "Edge", None)
 
     class EdgeBase:
-        node = Field(NonNull(_node) if strict_types else _node, description="The item at the end of the edge")
+        node = Field(
+            NonNull(_node) if strict_types else _node, 
+            description="The item at the end of the edge"
+        )
         cursor = String(required=True, description="A cursor for use in pagination")
 
     class EdgeMeta:
@@ -83,7 +89,9 @@ class Connection(ObjectType):
         abstract = True
 
     @classmethod
-    def __init_subclass_with_meta__(cls, node=None, name=None, strict_types=False, _meta=None, **options):
+    def __init_subclass_with_meta__(
+        cls, node=None, name=None, strict_types=False, _meta=None, **options
+    ):
         if not _meta:
             _meta = ConnectionOptions(cls)
         assert node, f"You have to provide a node in {cls.__name__}.Meta"

--- a/graphene/relay/tests/test_connection.py
+++ b/graphene/relay/tests/test_connection.py
@@ -299,3 +299,20 @@ def test_connectionfield_required():
     executed = schema.execute("{ testConnection { edges { cursor } } }")
     assert not executed.errors
     assert executed.data == {"testConnection": {"edges": []}}
+
+
+def test_connectionfield_strict_types():
+    class MyObjectConnection(Connection):
+        class Meta:
+            node = MyObject
+            strict_types = True
+
+    connection_field = ConnectionField(MyObjectConnection)
+    edges_field_type = connection_field.type._meta.fields["edges"].type
+    assert isinstance(edges_field_type, NonNull)
+
+    edges_list_element_type = edges_field_type.of_type.of_type
+    assert isinstance(edges_list_element_type, NonNull)
+
+    node_field = edges_list_element_type.of_type._meta.fields["node"]
+    assert isinstance(node_field.type, NonNull)


### PR DESCRIPTION
This PR adds a `strict_types` meta option to the relay `Connection` class to simplify the use case identified in this issue: https://github.com/graphql-python/graphene-django/issues/901

Default of `False` is the old behavior, and when set to `True` generated `TConnection` types will be typed as `edges: [TEdge!]!` instead of `edges: [TEdge]!` and `TEdge` will have `node: T!` instead of `node: T`.

This avoids duplicating logic and string descriptions for subclasses which just want to implement this common behavior. If this behavior is deemed desirable by default it would be trivial to flip the flag's default or remove it entirely. It only make the types stricter so it oughtn't break any existing code (though it will cause unexpected changes to user's schema's nonetheless, which is why I kept the default to `False`).