### PR TITLE
Allow the user to change InputObjectType's default value on non-specified inputs to a sentinel value

### DIFF
--- a/graphene/types/inputobjecttype.py
+++ b/graphene/types/inputobjecttype.py
@@ -14,6 +14,31 @@ class InputObjectTypeOptions(BaseOptions):
     container = None  # type: InputObjectTypeContainer
 
 
+# Currently in Graphene, we get a `None` whenever we access an (optional) field that was not set in an InputObjectType
+# using the InputObjectType.<attribute> dot access syntax. This is ambiguous, because in this current (Graphene
+# historical) arrangement, we cannot distinguish between a field not being set and a field being set to None.
+# At the same time, we shouldn't break existing code that expects a `None` when accessing a field that was not set.
+_INPUT_OBJECT_TYPE_DEFAULT_VALUE = None
+
+# To mitigate this, we provide the function `set_input_object_type_default_value` to allow users to change the default
+# value returned in non-specified fields in InputObjectType to another meaningful sentinel value (e.g. Undefined)
+# if they want to. This way, we can keep code that expects a `None` working while we figure out a better solution (or
+# a well-documented breaking change) for this issue.
+
+
+def set_input_object_type_default_value(default_value):
+    """
+    Change the sentinel value returned by non-specified fields in an InputObjectType
+    Useful to differentiate between a field not being set and a field being set to None by using a sentinel value
+    (e.g. Undefined is a good sentinel value for this purpose)
+
+    This function should be called at the beginning of the app or in some other place where it is guaranteed to
+    be called before any InputObjectType is defined.
+    """
+    global _INPUT_OBJECT_TYPE_DEFAULT_VALUE
+    _INPUT_OBJECT_TYPE_DEFAULT_VALUE = default_value
+
+
 class InputObjectTypeContainer(dict, BaseType):  # type: ignore
     class Meta:
         abstract = True
@@ -21,7 +46,7 @@ class InputObjectTypeContainer(dict, BaseType):  # type: ignore
     def __init__(self, *args, **kwargs):
         dict.__init__(self, *args, **kwargs)
         for key in self._meta.fields:
-            setattr(self, key, self.get(key, None))
+            setattr(self, key, self.get(key, _INPUT_OBJECT_TYPE_DEFAULT_VALUE))
 
     def __init_subclass__(cls, *args, **kwargs):
         pass

--- a/graphene/types/tests/conftest.py
+++ b/graphene/types/tests/conftest.py
@@ -1,0 +1,12 @@
+import pytest
+from graphql import Undefined
+
+from graphene.types.inputobjecttype import set_input_object_type_default_value
+
+
+@pytest.fixture()
+def set_default_input_object_type_to_undefined():
+    """This fixture is used to change the default value of optional inputs in InputObjectTypes for specific tests"""
+    set_input_object_type_default_value(Undefined)
+    yield
+    set_input_object_type_default_value(None)

--- a/graphene/types/tests/test_inputobjecttype.py
+++ b/graphene/types/tests/test_inputobjecttype.py
@@ -1,10 +1,9 @@
-import pytest
 from graphql import Undefined
 
 from ..argument import Argument
 from ..field import Field
 from ..inputfield import InputField
-from ..inputobjecttype import InputObjectType, set_input_object_type_default_value
+from ..inputobjecttype import InputObjectType
 from ..objecttype import ObjectType
 from ..scalars import Boolean, String
 from ..schema import Schema
@@ -140,14 +139,6 @@ def test_inputobjecttype_of_input():
 
     assert not result.errors
     assert result.data == {"isChild": True}
-
-
-@pytest.fixture()
-def set_default_input_object_type_to_undefined():
-    """This fixture is used to change the default value of optional inputs in InputObjectTypes for specific tests"""
-    set_input_object_type_default_value(Undefined)
-    yield
-    set_input_object_type_default_value(None)
 
 
 def test_inputobjecttype_default_input_as_undefined(

--- a/graphene/types/tests/test_type_map.py
+++ b/graphene/types/tests/test_type_map.py
@@ -16,12 +16,12 @@ from ..dynamic import Dynamic
 from ..enum import Enum
 from ..field import Field
 from ..inputfield import InputField
-from ..inputobjecttype import InputObjectType, set_input_object_type_default_value
+from ..inputobjecttype import InputObjectType
 from ..interface import Interface
 from ..objecttype import ObjectType
 from ..scalars import Int, String
-from ..structures import List, NonNull
 from ..schema import Schema
+from ..structures import List, NonNull
 
 
 def create_type_map(types, auto_camelcase=True):
@@ -227,9 +227,7 @@ def test_inputobject():
     assert foo_field.description == "Field description"
 
 
-def test_inputobject_undefined():
-    set_input_object_type_default_value(Undefined)
-
+def test_inputobject_undefined(set_default_input_object_type_to_undefined):
     class OtherObjectType(InputObjectType):
         optional_field = String()
 

--- a/graphene/types/tests/test_type_map.py
+++ b/graphene/types/tests/test_type_map.py
@@ -16,7 +16,7 @@ from ..dynamic import Dynamic
 from ..enum import Enum
 from ..field import Field
 from ..inputfield import InputField
-from ..inputobjecttype import InputObjectType
+from ..inputobjecttype import InputObjectType, set_input_object_type_default_value
 from ..interface import Interface
 from ..objecttype import ObjectType
 from ..scalars import Int, String
@@ -225,6 +225,20 @@ def test_inputobject():
     foo_field = fields["fooBar"]
     assert isinstance(foo_field, GraphQLInputField)
     assert foo_field.description == "Field description"
+
+
+def test_inputobject_undefined():
+    set_input_object_type_default_value(Undefined)
+
+    class OtherObjectType(InputObjectType):
+        optional_field = String()
+
+    type_map = create_type_map([OtherObjectType])
+    assert "OtherObjectType" in type_map
+    graphql_type = type_map["OtherObjectType"]
+
+    container = graphql_type.out_type({})
+    assert container.optional_field is Undefined
 
 
 def test_objecttype_camelcase():

--- a/graphene/validation/depth_limit.py
+++ b/graphene/validation/depth_limit.py
@@ -30,7 +30,7 @@ try:
 except ImportError:
     # backwards compatibility for v3.6
     from typing import Pattern
-from typing import Callable, Dict, List, Optional, Union
+from typing import Callable, Dict, List, Optional, Union, Tuple
 
 from graphql import GraphQLError
 from graphql.validation import ValidationContext, ValidationRule
@@ -82,7 +82,7 @@ def depth_limit_validator(
 
 
 def get_fragments(
-    definitions: List[DefinitionNode],
+    definitions: Tuple[DefinitionNode, ...],
 ) -> Dict[str, FragmentDefinitionNode]:
     fragments = {}
     for definition in definitions:
@@ -94,7 +94,7 @@ def get_fragments(
 # This will actually get both queries and mutations.
 # We can basically treat those the same
 def get_queries_and_mutations(
-    definitions: List[DefinitionNode],
+    definitions: Tuple[DefinitionNode, ...],
 ) -> Dict[str, OperationDefinitionNode]:
     operations = {}
 


### PR DESCRIPTION
This PR aims to remove the ambiguity that happens with `InputObjectType`s when accessing optional fields using the `input.<attribute>` "dot access" syntax.

### Current behavior:

If an optional input field is defined but has not been specified in an incoming `InputObjectType`, it comes back as a `None`

This is ambiguous, since the user could also have set that specific field to `None`, meaning we wouldn't be able to tell between an explicit setting to `None` versus the field not being set at all.

### Proposed behavior in this PR:

Introduce a non-breaking, opt-in method to allow the users to change this default value getter behavior in InputObjectTypes to any value that they want to. Graphene already provides such concept in the form of the `graphl.Undefined` value, which is a good example of a value that the user could use to differentiate between an optional input being explicitly set to `None` versus not being set at all.

The proposed API is a function called `set_input_object_type_default_value()` that allows the user to change the sentinel value that will be returned in optional inputs (it should be called early in the code, before any `InputObjectType`s are defined). The default value remains `None`, aligning with the current behavior, so as not to break existing code that relies on the current assumption.

#### _(Next steps and parting thoughts)_
Moving forward, I believe it'd be best to discuss around introducing a well documented breaking change that fixes this behavior altogether, eliminating such possibility. But the current PR should allow us to keep making progress while bigger fish are being fried :fish: :cook: 

Thanks!