### PR TITLE
Apply PEP 681 dataclass_transform to graphene ObjectTypeMeta

### DIFF
--- a/graphene/types/objecttype.py
+++ b/graphene/types/objecttype.py
@@ -1,4 +1,5 @@
-from typing import TYPE_CHECKING, dataclass_transform
+from typing import TYPE_CHECKING
+from typing_extensions import dataclass_transform
 
 from .base import BaseOptions, BaseType, BaseTypeMeta
 from .field import Field

--- a/graphene/types/objecttype.py
+++ b/graphene/types/objecttype.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, dataclass_transform
 
 from .base import BaseOptions, BaseType, BaseTypeMeta
 from .field import Field
@@ -19,6 +19,7 @@ class ObjectTypeOptions(BaseOptions):
     interfaces = ()  # type: Iterable[Type[Interface]]
 
 
+@dataclass_transform()
 class ObjectTypeMeta(BaseTypeMeta):
     def __new__(cls, name_, bases, namespace, **options):
         # Note: it's safe to pass options as keyword arguments as they are still type-checked by ObjectTypeOptions.

--- a/setup.py
+++ b/setup.py
@@ -86,6 +86,7 @@ setup(
         "graphql-core>=3.1,<3.3",
         "graphql-relay>=3.1,<3.3",
         "aniso8601>=8,<10",
+        "typing_extensions>=4.1.0",
     ],
     tests_require=tests_require,
     extras_require={"test": tests_require, "dev": dev_requires},


### PR DESCRIPTION
Following Eric Traut's advice here - https://github.com/microsoft/pyright/issues/5277#issuecomment-1588089626

This is a typing only fix that doesn't change any code behavior but helps type checkers. Essentially for pyright version 1.1.307+, when creating graphene.ObjectType that is returned, pyright will fail saying there are `Expected no arguments to "SomeObject" constructor`. This fixes the error and allows these members to be typed.