### PR TITLE
Simplify props.py

### DIFF
--- a/graphene/utils/props.py
+++ b/graphene/utils/props.py
@@ -1,15 +1,11 @@
-class _OldClass:
+class _Class:
     pass
 
 
-class _NewClass:
-    pass
-
-
-_all_vars = set(dir(_OldClass) + dir(_NewClass))
+_built_in_vars = set(dir(_Class))
 
 
 def props(x):
     return {
-        key: vars(x).get(key, getattr(x, key)) for key in dir(x) if key not in _all_vars
+        key: vars(x).get(key, getattr(x, key)) for key in dir(x) if key not in _built_in_vars
     }


### PR DESCRIPTION
It had code for handling the differences between old-style and new-style classes in Python 2, but support for Python 2 was dropped long ago.

This could be simplified further, e.g. by skipping any attributes that start with an underscore, but that would be a behavioural change, whereas this PR is a pure refactoring.