### PR TITLE
remove pytz

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,2 +1,2 @@
 [settings]
-known_third_party = aniso8601,graphql,graphql_relay,promise,pytest,pytz,pyutils,setuptools,snapshottest,sphinx_graphene_theme
+known_third_party = aniso8601,graphql,graphql_relay,promise,pytest,pyutils,setuptools,snapshottest,sphinx_graphene_theme

--- a/graphene/types/tests/test_datetime.py
+++ b/graphene/types/tests/test_datetime.py
@@ -1,6 +1,5 @@
 import datetime
 
-import pytz
 from graphql import GraphQLError
 
 from pytest import fixture
@@ -30,7 +29,7 @@ schema = Schema(query=Query)
 
 @fixture
 def sample_datetime():
-    utc_datetime = datetime.datetime(2019, 5, 25, 5, 30, 15, 10, pytz.utc)
+    utc_datetime = datetime.datetime(2019, 5, 25, 5, 30, 15, 10, datetime.timezone.utc)
     return utc_datetime
 
 

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,6 @@ tests_require = [
     "snapshottest>=0.6,<1",
     "coveralls>=3.3,<4",
     "mock>=4,<5",
-    "pytz==2022.1",
     "iso8601>=1,<2",
 ]
 


### PR DESCRIPTION
`pytz` is being deprecated, the usage of pytz in the package can be easily replaced by `datetime.timezone.utc`

I also plan to apply this commit to v2.