### PR TITLE
Fix enum value equality comparison

### DIFF
--- a/graphene/types/enum.py
+++ b/graphene/types/enum.py
@@ -9,7 +9,10 @@ from .unmountedtype import UnmountedType
 def eq_enum(self, other):
     if isinstance(other, self.__class__):
         return self is other
-    return self.value is other
+    if isinstance(other, PyEnum):
+        # Identical values from different Enum classes are not equal.
+        return False
+    return self.value == other
 
 
 def hash_enum(self):

--- a/graphene/types/tests/test_enum.py
+++ b/graphene/types/tests/test_enum.py
@@ -230,6 +230,25 @@ def test_enum_to_enum_comparison_should_differ():
     assert RGB1.BLUE != RGB2.BLUE
 
 
+def test_enum_to_value_comparison():
+    class RGB(Enum):
+        RED = "red"
+        GREEN = "green"
+        BLUE = "blue"
+
+    assert "red" == RGB.RED
+    assert "red" != RGB.GREEN
+    assert "red" != RGB.BLUE
+
+    assert "green" != RGB.RED
+    assert "green" == RGB.GREEN
+    assert "green" != RGB.BLUE
+
+    assert "blue" != RGB.RED
+    assert "blue" != RGB.GREEN
+    assert "blue" == RGB.BLUE
+
+
 def test_enum_skip_meta_from_members():
     class RGB1(Enum):
         class Meta:


### PR DESCRIPTION
Fix for https://github.com/graphql-python/graphene/issues/1524

This change takes care to preserve the current behavior where different enums with identical values are non-equal.

However it fixes inconsistent behavior when comparing enums to non-enum values. These comparisons would sometimes identify the non-enum values as equal and other times as non-equal due to `is` comparison.