### PR TITLE
Get rid of Deprecation Warnings

### DIFF
--- a/graphene/utils/subclass_with_meta.py
+++ b/graphene/utils/subclass_with_meta.py
@@ -40,7 +40,13 @@ class SubclassWithMeta(metaclass=SubclassWithMeta_Meta):
                 "Abstract types can only contain the abstract attribute. "
                 f"Received: abstract, {', '.join(options)}"
             )
+
         else:
+            if options.get("exclude_fields", None):
+                options["exclude"] = options.pop("exclude_fields")
+            elif not (options.get("fields", None) or options.get("exclude", None)):
+                options["fields"] = "__all__"
+
             super_class = super(cls, cls)
             if hasattr(super_class, "__init_subclass_with_meta__"):
                 super_class.__init_subclass_with_meta__(**options)


### PR DESCRIPTION
In my current project which depends on `graphene` (3.3) I encountered my logs unusable since they were heavily polluted with the following warning:

```
/home/wagtail/.local/lib/python3.9/site-packages/graphene/utils/subclass_with_meta.py:46: DeprecationWarning: Creating a DjangoObjectType without either the `fields` or the `exclude` option is deprecated. Add an explicit `fields = '__all__'` option on DjangoObjectType CollectionObjectType to use all fields
```

While trying to fix it just by adding the `fields="__all__"` option I stumbled upon this other one:

```
/home/wagtail/.local/lib/python3.9/site-packages/graphene/utils/subclass_with_meta.py:46: DeprecationWarning: Defining `exclude_fields` is deprecated in favour of `exclude`.
```

I believe this PR would make those warnings disappear without breaking anything AFAIK, at least that is what I found while testing it.

