### PR TITLE
bump pytest to 7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ class PyTest(TestCommand):
 tests_require = [
     "pytest>=7,<8",
     "pytest-benchmark>=4,<5",
-    "pytest-cov>=5,<6",
+    "pytest-cov>=4,<5",
     "pytest-mock>=3,<4",
     "pytest-asyncio>=0.16,<2",
     "snapshottest>=0.6,<1",

--- a/setup.py
+++ b/setup.py
@@ -45,9 +45,9 @@ class PyTest(TestCommand):
 
 
 tests_require = [
-    "pytest>=6,<7",
-    "pytest-benchmark>=3.4,<4",
-    "pytest-cov>=3,<4",
+    "pytest>=7,<8",
+    "pytest-benchmark>=4,<5",
+    "pytest-cov>=5,<6",
     "pytest-mock>=3,<4",
     "pytest-asyncio>=0.16,<2",
     "snapshottest>=0.6,<1",


### PR DESCRIPTION
pytest 8 is the latest version, and dropped support for Python 3.7. Also pytest-cov 5 dropped Python 3.7 too. I can update this PR to pytest 8 if https://github.com/graphql-python/graphene/pull/1543 is merged.