### PR TITLE
remove aniso8601, mock, iso8601

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,2 +1,2 @@
 [settings]
-known_third_party = aniso8601,graphql,graphql_relay,promise,pytest,pyutils,setuptools,snapshottest,sphinx_graphene_theme
+known_third_party = graphql,graphql_relay,promise,pytest,pyutils,setuptools,snapshottest,sphinx_graphene_theme

--- a/graphene/types/datetime.py
+++ b/graphene/types/datetime.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 
 import datetime
 
-from aniso8601 import parse_date, parse_datetime, parse_time
 from graphql.error import GraphQLError
 from graphql.language import StringValueNode, print_ast
 
@@ -39,7 +38,7 @@ class Date(Scalar):
         if not isinstance(value, str):
             raise GraphQLError(f"Date cannot represent non-string value: {repr(value)}")
         try:
-            return parse_date(value)
+            return datetime.date.fromisoformat(value)
         except ValueError:
             raise GraphQLError(f"Date cannot represent value: {repr(value)}")
 
@@ -74,7 +73,7 @@ class DateTime(Scalar):
                 f"DateTime cannot represent non-string value: {repr(value)}"
             )
         try:
-            return parse_datetime(value)
+            return datetime.datetime.fromisoformat(value)
         except ValueError:
             raise GraphQLError(f"DateTime cannot represent value: {repr(value)}")
 
@@ -107,6 +106,6 @@ class Time(Scalar):
         if not isinstance(value, str):
             raise GraphQLError(f"Time cannot represent non-string value: {repr(value)}")
         try:
-            return parse_time(value)
+            return datetime.time.fromisoformat(value)
         except ValueError:
             raise GraphQLError(f"Time cannot represent value: {repr(value)}")

--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,6 @@ setup(
     install_requires=[
         "graphql-core>=3.1,<3.3",
         "graphql-relay>=3.1,<3.3",
-        "aniso8601>=8,<10",
     ],
     tests_require=tests_require,
     extras_require={"test": tests_require, "dev": dev_requires},

--- a/setup.py
+++ b/setup.py
@@ -52,8 +52,6 @@ tests_require = [
     "pytest-asyncio>=0.16,<2",
     "snapshottest>=0.6,<1",
     "coveralls>=3.3,<4",
-    "mock>=4,<5",
-    "iso8601>=1,<2",
 ]
 
 dev_requires = ["black==22.3.0", "flake8>=4,<5"] + tests_require


### PR DESCRIPTION
Python 3.7 added **fromisoformat** functionality, so we can remove aniso8601. There are test cases for it, and all are passing..

Removing **mock**, because the documentation states below, so we don't need it.
> mock is now part of the Python standard library, available as [unittest.mock (https://docs.python.org/dev/library/unittest.mock.html) in Python 3.3 onwards.