### PR TITLE
pytest 8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ class PyTest(TestCommand):
 
 
 tests_require = [
-    "pytest>=7,<8",
+    "pytest>=8,<9",
     "pytest-benchmark>=4,<5",
     "pytest-cov>=4,<5",
     "pytest-mock>=3,<4",

--- a/setup.py
+++ b/setup.py
@@ -47,11 +47,11 @@ class PyTest(TestCommand):
 tests_require = [
     "pytest>=8,<9",
     "pytest-benchmark>=4,<5",
-    "pytest-cov>=4,<5",
+    "pytest-cov>=5,<6",
     "pytest-mock>=3,<4",
     "pytest-asyncio>=0.16,<2",
     "snapshottest>=0.6,<1",
-    "coveralls>=3.3,<4",
+    "coveralls>=4,<5",
 ]
 
 dev_requires = ["black==22.3.0", "flake8>=4,<5"] + tests_require


### PR DESCRIPTION
This PR bumps pytest version to 8, all tests are passing.

Please find a fix for lint at https://github.com/graphql-python/graphene/pull/1556