### PR TITLE
Lint using Ruff

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,2 +1,0 @@
-[settings]
-known_third_party = graphql,graphql_relay,promise,pytest,pyutils,setuptools,snapshottest,sphinx_graphene_theme

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,10 +22,7 @@ repos:
     -   id: pyupgrade
 -   repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.4.10
+    rev: v0.5.0
     hooks:
+        - id: ruff
         - id: ruff-format
--   repo: https://github.com/PyCQA/flake8
-    rev: 5.0.4
-    hooks:
-    -   id: flake8

--- a/bin/autolinter
+++ b/bin/autolinter
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-# Install the required scripts with
-# pip install autoflake autopep8 isort
-autoflake ./examples/ ./graphene/ -r --remove-unused-variables --remove-all-unused-imports --in-place
-autopep8 ./examples/ ./graphene/ -r --in-place --experimental --aggressive --max-line-length 120
-isort -rc ./examples/ ./graphene/

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,5 @@
 import os
+import sys
 
 import sphinx_graphene_theme
 
@@ -22,8 +23,6 @@ on_rtd = os.environ.get("READTHEDOCS", None) == "True"
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-import os
-import sys
 
 sys.path.insert(0, os.path.abspath(".."))
 

--- a/graphene/pyutils/version.py
+++ b/graphene/pyutils/version.py
@@ -71,6 +71,6 @@ def get_git_changeset():
         )
         timestamp = git_log.communicate()[0]
         timestamp = datetime.datetime.utcfromtimestamp(int(timestamp))
-    except:
+    except Exception:
         return None
     return timestamp.strftime("%Y%m%d%H%M%S")

--- a/graphene/relay/id_type.py
+++ b/graphene/relay/id_type.py
@@ -11,7 +11,7 @@ class BaseGlobalIDType:
     Base class that define the required attributes/method for a type.
     """
 
-    graphene_type = ID  # type: Type[BaseType]
+    graphene_type: Type[BaseType] = ID
 
     @classmethod
     def resolve_global_id(cls, info, global_id):

--- a/graphene/types/__init__.py
+++ b/graphene/types/__init__.py
@@ -1,4 +1,3 @@
-# flake8: noqa
 from graphql import GraphQLResolveInfo as ResolveInfo
 
 from .argument import Argument

--- a/graphene/types/base.py
+++ b/graphene/types/base.py
@@ -1,17 +1,17 @@
-from typing import Type
+from typing import Type, Optional
 
 from ..utils.subclass_with_meta import SubclassWithMeta, SubclassWithMeta_Meta
 from ..utils.trim_docstring import trim_docstring
 
 
 class BaseOptions:
-    name = None  # type: str
-    description = None  # type: str
+    name: Optional[str] = None
+    description: Optional[str] = None
 
-    _frozen = False  # type: bool
+    _frozen: bool = False
 
-    def __init__(self, class_type):
-        self.class_type = class_type  # type: Type
+    def __init__(self, class_type: Type):
+        self.class_type: Type = class_type
 
     def freeze(self):
         self._frozen = True

--- a/graphene/types/scalars.py
+++ b/graphene/types/scalars.py
@@ -121,8 +121,7 @@ class Float(Scalar):
     """
 
     @staticmethod
-    def coerce_float(value):
-        # type: (Any) -> float
+    def coerce_float(value: Any) -> float:
         try:
             return float(value)
         except ValueError:

--- a/graphene/utils/dataloader.py
+++ b/graphene/utils/dataloader.py
@@ -9,7 +9,7 @@ from collections import namedtuple
 from collections.abc import Iterable
 from functools import partial
 
-from typing import List  # flake8: noqa
+from typing import List
 
 Loader = namedtuple("Loader", "key,future")
 

--- a/graphene/utils/dataloader.py
+++ b/graphene/utils/dataloader.py
@@ -62,7 +62,7 @@ class DataLoader(object):
         self.get_cache_key = get_cache_key or (lambda x: x)
 
         self._cache = cache_map if cache_map is not None else {}
-        self._queue = []  # type: List[Loader]
+        self._queue: List[Loader] = []
 
     @property
     def loop(self):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,16 +1,5 @@
-[flake8]
-exclude = setup.py,docs/*,*/examples/*,graphene/pyutils/*,tests
-max-line-length = 120
-
-# This is a specific ignore for Black+Flake8
-# source: https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html#id1
-extend-ignore = E203
-
 [coverage:run]
 omit = graphene/pyutils/*,*/tests/*,graphene/types/scalars.py
-
-[isort]
-known_first_party=graphene
 
 [bdist_wheel]
 universal=1

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ tests_require = [
     "coveralls>=4,<5",
 ]
 
-dev_requires = ["ruff==0.4.10", "flake8>=4,<5"] + tests_require
+dev_requires = ["ruff==0.5.0"] + tests_require
 
 setup(
     name="graphene",


### PR DESCRIPTION
Ruff is modern linter that replaces flake8, isort and other linting tools, thus removing flake8. I'll add more lint check once merged.

Python 3.13 testing is fixed in https://github.com/graphql-python/graphene/pull/1562