### PR TITLE
CI: build package

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,21 @@
+name: 📦 Build
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.10"
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install build twine
+    - name: Building package
+      run: python3 -m build
+    - name: Check package with Twine
+      run: twine check dist/*


### PR DESCRIPTION
I would like to [modernize](https://packaging.python.org/en/latest/guides/modernize-setup-py-project/) packaging, also thought CI for building packages would be helpful for QA.

Tests on Python 3.13 are fixed in https://github.com/graphql-python/graphene/pull/1562