### PR TITLE
bump mypy to 1.10

### DIFF
--- a/graphene/utils/deprecated.py
+++ b/graphene/utils/deprecated.py
@@ -27,9 +27,9 @@ def deprecated(reason):
 
         def decorator(func1):
             if inspect.isclass(func1):
-                fmt1 = f"Call to deprecated class {func1.__name__} ({reason!r})."
+                fmt1 = f"Call to deprecated class {func1.__name__} ({reason.decode()})."
             else:
-                fmt1 = f"Call to deprecated function {func1.__name__} ({reason!r})."
+                fmt1 = f"Call to deprecated function {func1.__name__} ({reason.decode()})."
 
             @functools.wraps(func1)
             def new_func1(*args, **kwargs):

--- a/graphene/utils/deprecated.py
+++ b/graphene/utils/deprecated.py
@@ -27,9 +27,9 @@ def deprecated(reason):
 
         def decorator(func1):
             if inspect.isclass(func1):
-                fmt1 = f"Call to deprecated class {func1.__name__} ({reason})."
+                fmt1 = f"Call to deprecated class {func1.__name__} ({reason!r})."
             else:
-                fmt1 = f"Call to deprecated function {func1.__name__} ({reason})."
+                fmt1 = f"Call to deprecated function {func1.__name__} ({reason!r})."
 
             @functools.wraps(func1)
             def new_func1(*args, **kwargs):

--- a/graphene/utils/deprecated.py
+++ b/graphene/utils/deprecated.py
@@ -24,12 +24,13 @@ def deprecated(reason):
         #    @deprecated("please, use another function")
         #    def old_function(x, y):
         #      pass
+        reason = reason.decode() if isinstance(reason, bytes) else reason
 
         def decorator(func1):
             if inspect.isclass(func1):
-                fmt1 = f"Call to deprecated class {func1.__name__} ({reason.decode()})."
+                fmt1 = f"Call to deprecated class {func1.__name__} ({reason})."
             else:
-                fmt1 = f"Call to deprecated function {func1.__name__} ({reason.decode()})."
+                fmt1 = f"Call to deprecated function {func1.__name__} ({reason})."
 
             @functools.wraps(func1)
             def new_func1(*args, **kwargs):

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ commands =
 [testenv:mypy]
 basepython = python3.10
 deps =
-    mypy>=0.950,<1
+    mypy>=1.10,<2
 commands =
     mypy graphene
 


### PR DESCRIPTION
This PR bumps mypy, and fixes below error.

```python
graphene/utils/deprecated.py:30: error: If x = b'abc' then f"{x}" or "{}".format(x) produces "b'abc'", not "abc". If this is desired behavior, use f"{x!r}" or "{!r}".format(x). Otherwise, decode the bytes  [str-bytes-safe]
graphene/utils/deprecated.py:32: error: If x = b'abc' then f"{x}" or "{}".format(x) produces "b'abc'", not "abc". If this is desired behavior, use f"{x!r}" or "{!r}".format(x). Otherwise, decode the bytes  [str-bytes-safe]
```