### PR TITLE
Override Union meta

### DIFF
--- a/graphene/types/union.py
+++ b/graphene/types/union.py
@@ -56,7 +56,7 @@ class Union(UnmountedType, BaseType):
             isinstance(types, (list, tuple)) and len(types) > 0
         ), f"Must provide types for Union {cls.__name__}."
 
-        if _meta is None:
+        if not _meta:
             _meta = UnionOptions(cls)
 
         _meta.types = types

--- a/graphene/types/union.py
+++ b/graphene/types/union.py
@@ -56,7 +56,7 @@ class Union(UnmountedType, BaseType):
             isinstance(types, (list, tuple)) and len(types) > 0
         ), f"Must provide types for Union {cls.__name__}."
 
-        _meta = UnionOptions(cls)
+        _meta = options.pop("_meta", UnionOptions(cls))
         _meta.types = types
         super(Union, cls).__init_subclass_with_meta__(_meta=_meta, **options)
 

--- a/graphene/types/union.py
+++ b/graphene/types/union.py
@@ -51,12 +51,14 @@ class Union(UnmountedType, BaseType):
     """
 
     @classmethod
-    def __init_subclass_with_meta__(cls, types=None, **options):
+    def __init_subclass_with_meta__(cls, types=None, _meta=None, **options):
         assert (
             isinstance(types, (list, tuple)) and len(types) > 0
         ), f"Must provide types for Union {cls.__name__}."
 
-        _meta = options.pop("_meta", UnionOptions(cls))
+        if _meta is None:
+            _meta = UnionOptions(cls)
+
         _meta.types = types
         super(Union, cls).__init_subclass_with_meta__(_meta=_meta, **options)
 


### PR DESCRIPTION
This gives us the option to add our own `_meta` to `Union`

Allowing us to implement features such as [this](https://github.com/graphql-python/graphene-django/pull/1537)