### PR TITLE
[FIX] Decimal scalar inaccurate conversion of float to decimal

### DIFF
--- a/graphene/types/decimal.py
+++ b/graphene/types/decimal.py
@@ -1,7 +1,7 @@
 from decimal import Decimal as _Decimal
 
 from graphql import Undefined
-from graphql.language.ast import StringValueNode, IntValueNode
+from graphql.language.ast import StringValueNode, IntValueNode, FloatValueNode
 
 from .scalars import Scalar
 
@@ -22,13 +22,13 @@ class Decimal(Scalar):
 
     @classmethod
     def parse_literal(cls, node, _variables=None):
-        if isinstance(node, (StringValueNode, IntValueNode)):
+        if isinstance(node, (StringValueNode, IntValueNode, FloatValueNode)):
             return cls.parse_value(node.value)
         return Undefined
 
     @staticmethod
     def parse_value(value):
         try:
-            return _Decimal(value)
+            return _Decimal(str(value))
         except Exception:
             return Undefined

--- a/graphene/types/tests/test_decimal.py
+++ b/graphene/types/tests/test_decimal.py
@@ -23,12 +23,58 @@ def test_decimal_string_query():
     assert decimal.Decimal(result.data["decimal"]) == decimal_value
 
 
+def test_decimal_float_query():
+    float_value = 1969.1974
+    decimal_value = decimal.Decimal(str(float_value))
+    result = schema.execute("""{ decimal(input: %s) }""" % float_value)
+    assert not result.errors
+    assert not result.errors
+    assert result.data == {"decimal": str(decimal_value)}
+    assert decimal.Decimal(result.data["decimal"]) == decimal_value
+
+
+def test_decimal_int_query():
+    int_value = 1234
+    decimal_value = decimal.Decimal(str(int_value))
+    result = schema.execute("""{ decimal(input: %s) }""" % int_value)
+    assert not result.errors
+    assert not result.errors
+    assert result.data == {"decimal": str(decimal_value)}
+    assert decimal.Decimal(result.data["decimal"]) == decimal_value
+
+
 def test_decimal_string_query_variable():
     decimal_value = decimal.Decimal("1969.1974")
 
     result = schema.execute(
         """query Test($decimal: Decimal){ decimal(input: $decimal) }""",
         variables={"decimal": decimal_value},
+    )
+    assert not result.errors
+    assert result.data == {"decimal": str(decimal_value)}
+    assert decimal.Decimal(result.data["decimal"]) == decimal_value
+
+
+def test_decimal_float_query_variable():
+    float_value = 1969.1974
+    decimal_value = decimal.Decimal(str(float_value))
+
+    result = schema.execute(
+        """query Test($decimal: Decimal){ decimal(input: $decimal) }""",
+        variables={"decimal": float_value},
+    )
+    assert not result.errors
+    assert result.data == {"decimal": str(decimal_value)}
+    assert decimal.Decimal(result.data["decimal"]) == decimal_value
+
+
+def test_decimal_int_query_variable():
+    int_value = 1234
+    decimal_value = decimal.Decimal(str(int_value))
+
+    result = schema.execute(
+        """query Test($decimal: Decimal){ decimal(input: $decimal) }""",
+        variables={"decimal": int_value},
     )
     assert not result.errors
     assert result.data == {"decimal": str(decimal_value)}
@@ -52,12 +98,6 @@ def test_bad_decimal_query():
     assert len(result.errors) == 1
     assert result.data is None
     assert result.errors[0].message == "Expected value of type 'Decimal', found true."
-
-    result = schema.execute("{ decimal(input: 1.2) }")
-    assert result.errors
-    assert len(result.errors) == 1
-    assert result.data is None
-    assert result.errors[0].message == "Expected value of type 'Decimal', found 1.2."
 
 
 def test_decimal_string_query_integer():


### PR DESCRIPTION
Fixes https://github.com/graphql-python/graphene/issues/1593

Example:-
`Decimal(0.01)` created a value `Decimal("0.01000000000000000020816681711721685132943093776702880859375")`

Additional:
The Decimal field now accepts string, int & float. Previously, it was just string & int